### PR TITLE
Add diagnostics for Managed Beans

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,4 +14,3 @@ target/
 
 .metadata
 **/*.jar
-.vscode/

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ target/
 
 .metadata
 **/*.jar
+.vscode/

--- a/jakarta-eclipse/org.eclipse.lsp4jakarta.core/src/org/jakarta/codeAction/CodeActionHandler.java
+++ b/jakarta-eclipse/org.eclipse.lsp4jakarta.core/src/org/jakarta/codeAction/CodeActionHandler.java
@@ -32,6 +32,8 @@ import org.jakarta.jdt.JDTUtils;
 import org.jakarta.jdt.JsonRpcHelpers;
 import org.jakarta.jdt.jax_rs.Jax_RSConstants;
 import org.jakarta.jdt.jax_rs.ResourceMethodQuickFix;
+import org.jakarta.jdt.cdi.ManagedBeanConstants;
+import org.jakarta.jdt.cdi.ManagedBeanQuickFix;
 import org.jakarta.jdt.servlet.CompleteFilterAnnotationQuickFix;
 import org.jakarta.jdt.servlet.CompleteServletAnnotationQuickFix;
 import org.jakarta.jdt.servlet.FilterImplementationQuickFix;
@@ -78,8 +80,7 @@ public class CodeActionHandler {
             CompleteFilterAnnotationQuickFix CompleteFilterAnnotationQuickFix = new CompleteFilterAnnotationQuickFix();
             DeleteConflictMapKeyQuickFix DeleteConflictMapKeyQuickFix = new DeleteConflictMapKeyQuickFix();
             ResourceMethodQuickFix ResourceMethodQuickFix = new ResourceMethodQuickFix();
-
-
+            ManagedBeanQuickFix ManagedBeanQuickFix = new ManagedBeanQuickFix();
 
             for (Diagnostic diagnostic : params.getContext().getDiagnostics()) {
                 try {
@@ -93,18 +94,28 @@ public class CodeActionHandler {
                         codeActions.addAll(ListenerImplementationQuickFix.getCodeActions(context, diagnostic, monitor));
                     }
                     if (diagnostic.getCode().getLeft().equals(ServletConstants.DIAGNOSTIC_CODE_MISSING_ATTRIBUTE)
-                        || diagnostic.getCode().getLeft().equals(ServletConstants.DIAGNOSTIC_CODE_DUPLICATE_ATTRIBUTES)) {
-                        codeActions.addAll(CompleteServletAnnotationQuickFix.getCodeActions(context, diagnostic, monitor));
+                            || diagnostic.getCode().getLeft()
+                                    .equals(ServletConstants.DIAGNOSTIC_CODE_DUPLICATE_ATTRIBUTES)) {
+                        codeActions
+                                .addAll(CompleteServletAnnotationQuickFix.getCodeActions(context, diagnostic, monitor));
                     }
-                    if(diagnostic.getCode().getLeft().equals(ServletConstants.DIAGNOSTIC_CODE_FILTER_MISSING_ATTRIBUTE)
-                        || diagnostic.getCode().getLeft().equals(ServletConstants.DIAGNOSTIC_CODE_FILTER_DUPLICATE_ATTRIBUTES)) {
-                        codeActions.addAll(CompleteFilterAnnotationQuickFix.getCodeActions(context, diagnostic, monitor));
+                    if (diagnostic.getCode().getLeft().equals(ServletConstants.DIAGNOSTIC_CODE_FILTER_MISSING_ATTRIBUTE)
+                            || diagnostic.getCode().getLeft()
+                                    .equals(ServletConstants.DIAGNOSTIC_CODE_FILTER_DUPLICATE_ATTRIBUTES)) {
+                        codeActions
+                                .addAll(CompleteFilterAnnotationQuickFix.getCodeActions(context, diagnostic, monitor));
                     }
                     if (diagnostic.getCode().getLeft().equals(Jax_RSConstants.DIAGNOSTIC_CODE_NON_PUBLIC)) {
                         codeActions.addAll(ResourceMethodQuickFix.getCodeActions(context, diagnostic, monitor));
                     }
                     if(diagnostic.getCode().getLeft().equals(PersistenceConstants.DIAGNOSTIC_CODE_INVALID_ANNOTATION)) {
                         codeActions.addAll(DeleteConflictMapKeyQuickFix.getCodeActions(context, diagnostic, monitor));
+                    if (diagnostic.getCode().getLeft()
+                            .equals(PersistenceConstants.DIAGNOSTIC_CODE_INVALID_ANNOTATION)) {
+                        codeActions.addAll(DeleteConflictMapKeyQuickFix.getCodeActions(context, diagnostic, monitor));
+                    }
+                    if (diagnostic.getCode().getLeft().equals(ManagedBeanConstants.DIAGNOSTIC_CODE)) {
+                        codeActions.addAll(ManagedBeanQuickFix.getCodeActions(context, diagnostic, monitor));
                     }
                 } catch (CoreException e) {
                     e.printStackTrace();

--- a/jakarta-eclipse/org.eclipse.lsp4jakarta.core/src/org/jakarta/codeAction/CodeActionHandler.java
+++ b/jakarta-eclipse/org.eclipse.lsp4jakarta.core/src/org/jakarta/codeAction/CodeActionHandler.java
@@ -108,8 +108,6 @@ public class CodeActionHandler {
                     if (diagnostic.getCode().getLeft().equals(Jax_RSConstants.DIAGNOSTIC_CODE_NON_PUBLIC)) {
                         codeActions.addAll(ResourceMethodQuickFix.getCodeActions(context, diagnostic, monitor));
                     }
-                    if(diagnostic.getCode().getLeft().equals(PersistenceConstants.DIAGNOSTIC_CODE_INVALID_ANNOTATION)) {
-                        codeActions.addAll(DeleteConflictMapKeyQuickFix.getCodeActions(context, diagnostic, monitor));
                     if (diagnostic.getCode().getLeft()
                             .equals(PersistenceConstants.DIAGNOSTIC_CODE_INVALID_ANNOTATION)) {
                         codeActions.addAll(DeleteConflictMapKeyQuickFix.getCodeActions(context, diagnostic, monitor));

--- a/jakarta-eclipse/org.eclipse.lsp4jakarta.core/src/org/jakarta/codeAction/JavaCodeActionContext.java
+++ b/jakarta-eclipse/org.eclipse.lsp4jakarta.core/src/org/jakarta/codeAction/JavaCodeActionContext.java
@@ -108,6 +108,7 @@ public class JavaCodeActionContext extends AbstractJavaContext implements IInvoc
             return null;
         }
         CodeAction codeAction = new CodeAction();
+        codeAction.setTitle(name);
         codeAction.setKind(proposal.getKind());
         codeAction.setEdit(edit);
         codeAction.setDiagnostics(Arrays.asList(diagnostics));

--- a/jakarta-eclipse/org.eclipse.lsp4jakarta.core/src/org/jakarta/codeAction/proposal/ReplaceAnnotationProposal.java
+++ b/jakarta-eclipse/org.eclipse.lsp4jakarta.core/src/org/jakarta/codeAction/proposal/ReplaceAnnotationProposal.java
@@ -1,0 +1,112 @@
+/*******************************************************************************
+ * Copyright (c) 2000, 2016 IBM Corporation and others.
+* This program and the accompanying materials are made available under the
+* terms of the Eclipse Public License v. 2.0 which is available at
+* http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+* which is available at https://www.apache.org/licenses/LICENSE-2.0.
+*
+* SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ *
+ * Copied from /org.eclipse.jdt.ui/src/org/eclipse/jdt/internal/ui/text/correction/proposals/NewAnnotationMemberProposal.java
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package org.jakarta.codeAction.proposal;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.dom.AST;
+import org.eclipse.jdt.core.dom.ASTNode;
+import org.eclipse.jdt.core.dom.Annotation;
+import org.eclipse.jdt.core.dom.CompilationUnit;
+import org.eclipse.jdt.core.dom.FieldDeclaration;
+import org.eclipse.jdt.core.dom.IAnnotationBinding;
+import org.eclipse.jdt.core.dom.IBinding;
+import org.eclipse.jdt.core.dom.TypeDeclaration;
+import org.eclipse.jdt.core.dom.VariableDeclarationFragment;
+import org.eclipse.jdt.core.dom.rewrite.ASTRewrite;
+import org.eclipse.jdt.core.dom.rewrite.ImportRewrite;
+import org.eclipse.jdt.core.dom.rewrite.ImportRewrite.ImportRewriteContext;
+import org.eclipse.jdt.internal.core.manipulation.dom.ASTResolving;
+import org.eclipse.jdt.internal.corext.codemanipulation.ContextSensitiveImportRewriteContext;
+
+/**
+ * Similar functionality as NewAnnotationProposal. The main difference is that
+ * first removes specified annotations before adding a new annotation.
+ * 
+ * Note: This class only accepts one new annotation to add.
+ * 
+ * @author Kathryn Kodama
+ */
+public class ReplaceAnnotationProposal extends NewAnnotationProposal {
+
+	private final String[] removeAnnotations;
+
+	public ReplaceAnnotationProposal(String label, ICompilationUnit targetCU, CompilationUnit invocationNode,
+			IBinding binding, int relevance, String annotation, String... removeAnnotations) {
+		super(label, targetCU, invocationNode, binding, relevance, annotation);
+		this.removeAnnotations = removeAnnotations;
+	}
+
+	@Override
+	protected ASTRewrite getRewrite() throws CoreException {
+		CompilationUnit fInvocationNode = getInvocationNode();
+		IBinding fBinding = getBinding();
+		String[] annotations = getAnnotations();
+
+		ASTNode declNode = null;
+		ASTNode boundNode = fInvocationNode.findDeclaringNode(fBinding);
+		CompilationUnit newRoot = fInvocationNode;
+		if (boundNode != null) {
+			declNode = boundNode; // is same CU
+		} else {
+			newRoot = ASTResolving.createQuickFixAST(getCompilationUnit(), null);
+			declNode = newRoot.findDeclaringNode(fBinding.getKey());
+		}
+		ImportRewrite imports = createImportRewrite(newRoot);
+
+		boolean isField = declNode instanceof VariableDeclarationFragment;
+		if (isField) {
+			declNode = declNode.getParent();
+		}
+		if (declNode instanceof TypeDeclaration || isField) {	
+			AST ast = declNode.getAST();
+			ASTRewrite rewrite = ASTRewrite.create(ast);
+
+			ImportRewriteContext importRewriteContext = new ContextSensitiveImportRewriteContext(declNode, imports);
+
+			// remove annotations in the removeAnnotations list
+			@SuppressWarnings("unchecked")
+			List<? extends ASTNode> children = (List<? extends ASTNode>) (declNode.getParent() instanceof CompilationUnit ? declNode : declNode.getParent())
+					.getStructuralProperty(TypeDeclaration.MODIFIERS2_PROPERTY);
+			for (ASTNode child : children) {
+				if (child instanceof Annotation) {
+					Annotation annotation = (Annotation) child;
+					IAnnotationBinding annotationBinding = annotation.resolveAnnotationBinding();
+					boolean containsAnnotation = Arrays.stream(removeAnnotations)
+							.anyMatch(annotationBinding.getName()::contains);
+					if (containsAnnotation) {
+						rewrite.remove(child, null);
+					}
+				}
+			}
+			for (String annotation : annotations) {
+				Annotation marker = ast.newMarkerAnnotation();
+				marker.setTypeName(ast.newName(imports.addImport(annotation, importRewriteContext))); // $NON-NLS-1$
+				rewrite.getListRewrite(declNode,
+						isField ? FieldDeclaration.MODIFIERS2_PROPERTY : TypeDeclaration.MODIFIERS2_PROPERTY)
+						.insertFirst(marker, null);
+			}
+
+			return rewrite;
+		}
+		return null;
+	}
+	
+
+
+}

--- a/jakarta-eclipse/org.eclipse.lsp4jakarta.core/src/org/jakarta/jdt/JDTServicesManager.java
+++ b/jakarta-eclipse/org.eclipse.lsp4jakarta.core/src/org/jakarta/jdt/JDTServicesManager.java
@@ -30,6 +30,7 @@ import org.eclipse.lsp4j.PublishDiagnosticsParams;
 import org.jakarta.jdt.beanvalidation.BeanValidationDiagnosticsCollector;
 import org.jakarta.jdt.jax_rs.ResourceMethodDiagnosticsCollector;
 import org.jakarta.jdt.jsonb.JsonbCreatorDiagnosticsCollector;
+import org.jakarta.jdt.cdi.ManagedBeanDiagnosticsCollector;
 import org.jakarta.jdt.persistence.PersistenceEntityDiagnosticsCollector;
 import org.jakarta.jdt.persistence.PersistenceMapKeyDiagnosticsCollector;
 import org.jakarta.jdt.servlet.FilterDiagnosticsCollector;
@@ -43,9 +44,10 @@ import io.microshed.jakartals.commons.JakartaJavaCodeActionParams;
 import org.jakarta.codeAction.CodeActionHandler;
 
 /**
- * JDT manager for Java files
- * Modified from https://github.com/eclipse/lsp4mp/blob/master/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/jdt/core/PropertiesManagerForJava.java
- * with methods modified and removed to fit the purposes of the Jakarta Language Server
+ * JDT manager for Java files Modified from
+ * https://github.com/eclipse/lsp4mp/blob/master/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/jdt/core/PropertiesManagerForJava.java
+ * with methods modified and removed to fit the purposes of the Jakarta Language
+ * Server
  * 
  */
 public class JDTServicesManager {
@@ -69,6 +71,7 @@ public class JDTServicesManager {
         diagnosticsCollectors.add(new PersistenceMapKeyDiagnosticsCollector());
         diagnosticsCollectors.add(new ResourceMethodDiagnosticsCollector());
         diagnosticsCollectors.add(new JsonbCreatorDiagnosticsCollector());
+        diagnosticsCollectors.add(new ManagedBeanDiagnosticsCollector());
         this.codeActionHandler = new CodeActionHandler();
     }
 

--- a/jakarta-eclipse/org.eclipse.lsp4jakarta.core/src/org/jakarta/jdt/cdi/ManagedBeanConstants.java
+++ b/jakarta-eclipse/org.eclipse.lsp4jakarta.core/src/org/jakarta/jdt/cdi/ManagedBeanConstants.java
@@ -1,0 +1,8 @@
+package org.jakarta.jdt.cdi;
+
+import org.eclipse.lsp4j.DiagnosticSeverity;
+
+public class ManagedBeanConstants {
+    public static final String DIAGNOSTIC_SOURCE = "jakarta-cdi";
+    public static final DiagnosticSeverity SEVERITY = DiagnosticSeverity.Error;
+}

--- a/jakarta-eclipse/org.eclipse.lsp4jakarta.core/src/org/jakarta/jdt/cdi/ManagedBeanConstants.java
+++ b/jakarta-eclipse/org.eclipse.lsp4jakarta.core/src/org/jakarta/jdt/cdi/ManagedBeanConstants.java
@@ -1,8 +1,15 @@
 package org.jakarta.jdt.cdi;
 
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
 import org.eclipse.lsp4j.DiagnosticSeverity;
 
 public class ManagedBeanConstants {
     public static final String DIAGNOSTIC_SOURCE = "jakarta-cdi";
+    public static final String DIAGNOSTIC_CODE = "InvalidManagedBeanAnnotation";
     public static final DiagnosticSeverity SEVERITY = DiagnosticSeverity.Error;
+    public static final Set<String> SCOPES = new HashSet<String>(
+            Arrays.asList("Dependent", "ApplicationScoped", "ConversationScoped", "RequestScoped", "SessionScoped"));
 }

--- a/jakarta-eclipse/org.eclipse.lsp4jakarta.core/src/org/jakarta/jdt/cdi/ManagedBeanConstants.java
+++ b/jakarta-eclipse/org.eclipse.lsp4jakarta.core/src/org/jakarta/jdt/cdi/ManagedBeanConstants.java
@@ -1,3 +1,16 @@
+/*******************************************************************************
+* Copyright (c) 2021 IBM Corporation.
+*
+* This program and the accompanying materials are made available under the
+* terms of the Eclipse Public License v. 2.0 which is available at
+* http://www.eclipse.org/legal/epl-2.0.
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*     Hani Damlaj
+*******************************************************************************/
+
 package org.jakarta.jdt.cdi;
 
 import java.util.Arrays;

--- a/jakarta-eclipse/org.eclipse.lsp4jakarta.core/src/org/jakarta/jdt/cdi/ManagedBeanDiagnosticsCollector.java
+++ b/jakarta-eclipse/org.eclipse.lsp4jakarta.core/src/org/jakarta/jdt/cdi/ManagedBeanDiagnosticsCollector.java
@@ -35,9 +35,7 @@ import org.jakarta.lsp4e.Activator;
 import static org.jakarta.jdt.cdi.ManagedBeanConstants.*;
 
 public class ManagedBeanDiagnosticsCollector implements DiagnosticsCollector {
-    private static final Set<String> SCOPES = new HashSet<String>(
-            Arrays.asList("Dependent", "ApplicationScoped", "ConversationScoped", "RequestScoped", "SessionScoped"));
-
+	
     private Diagnostic createDiagnostic(ICompilationUnit unit, IJavaElement el, String message)
             throws JavaModelException {
         ISourceRange nameRange = JDTUtils.getNameRange(el);
@@ -86,6 +84,7 @@ public class ManagedBeanDiagnosticsCollector implements DiagnosticsCollector {
                                     .anyMatch(annotation -> !annotation.equals("Dependent"))) {
                         Diagnostic diagnostic = createDiagnostic(unit, field,
                                 "A managed bean with a non-static public field must not declare any scope other than @Dependent");
+                        diagnostic.setCode(DIAGNOSTIC_CODE);
                         diagnostics.add(diagnostic);
                     }
                 }

--- a/jakarta-eclipse/org.eclipse.lsp4jakarta.core/src/org/jakarta/jdt/cdi/ManagedBeanDiagnosticsCollector.java
+++ b/jakarta-eclipse/org.eclipse.lsp4jakarta.core/src/org/jakarta/jdt/cdi/ManagedBeanDiagnosticsCollector.java
@@ -1,0 +1,97 @@
+/*******************************************************************************
+* Copyright (c) 2021 IBM Corporation.
+*
+* This program and the accompanying materials are made available under the
+* terms of the Eclipse Public License v. 2.0 which is available at
+* http://www.eclipse.org/legal/epl-2.0.
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*     Hani Damlaj
+*******************************************************************************/
+
+package org.jakarta.jdt.cdi;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.eclipse.jdt.core.Flags;
+import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.IField;
+import org.eclipse.jdt.core.IJavaElement;
+import org.eclipse.jdt.core.ISourceRange;
+import org.eclipse.jdt.core.IType;
+import org.eclipse.jdt.core.JavaModelException;
+import org.eclipse.lsp4j.Diagnostic;
+import org.eclipse.lsp4j.Range;
+import org.jakarta.jdt.DiagnosticsCollector;
+import org.jakarta.jdt.JDTUtils;
+import org.jakarta.lsp4e.Activator;
+
+import static org.jakarta.jdt.cdi.ManagedBeanConstants.*;
+
+public class ManagedBeanDiagnosticsCollector implements DiagnosticsCollector {
+    private static final Set<String> SCOPES = new HashSet<String>(
+            Arrays.asList("Dependent", "ApplicationScoped", "ConversationScoped", "RequestScoped", "SessionScoped"));
+
+    private Diagnostic createDiagnostic(ICompilationUnit unit, IJavaElement el, String message)
+            throws JavaModelException {
+        ISourceRange nameRange = JDTUtils.getNameRange(el);
+        Range range = JDTUtils.toRange(unit, nameRange.getOffset(), nameRange.getLength());
+        Diagnostic diagnostic = new Diagnostic(range, message);
+        completeDiagnostic(diagnostic);
+        return diagnostic;
+    }
+
+    @Override
+    public void completeDiagnostic(Diagnostic diagnostic) {
+        diagnostic.setSource(DIAGNOSTIC_SOURCE);
+        diagnostic.setSeverity(SEVERITY);
+    }
+
+    @Override
+    public void collectDiagnostics(ICompilationUnit unit, List<Diagnostic> diagnostics) {
+        if (unit == null)
+            return;
+
+        List<String> managedBeanAnnotations;
+
+        try {
+            for (IType type : unit.getAllTypes()) {
+                // Construct a stream of only the annotations applied to the type that are also
+                // recognised managed bean annotations.
+                managedBeanAnnotations = Arrays.stream(type.getAnnotations())
+                        .map(annotation -> annotation.getElementName()).filter(SCOPES::contains).distinct()
+                        .collect(Collectors.toList());
+
+                boolean isManagedBean = managedBeanAnnotations.size() > 0;
+
+                for (IField field : type.getFields()) {
+                    int fieldFlags = field.getFlags();
+
+                    /**
+                     * If a managed bean has a non-static public field, it must have
+                     * scope @Dependent. If a managed bean with a non-static public field declares
+                     * any scope other than @Dependent, the container automatically detects the
+                     * problem and treats it as a definition error.
+                     * 
+                     * https://jakarta.ee/specifications/cdi/2.0/cdi-spec-2.0.html#managed_beans
+                     */
+                    if (isManagedBean && Flags.isPublic(fieldFlags) && !Flags.isStatic(fieldFlags)
+                            && managedBeanAnnotations.stream()
+                                    .anyMatch(annotation -> !annotation.equals("Dependent"))) {
+                        Diagnostic diagnostic = createDiagnostic(unit, field,
+                                "A managed bean with a non-static public field must not declare any scope other than @Dependent");
+                        diagnostics.add(diagnostic);
+                    }
+                }
+            }
+        } catch (JavaModelException e) {
+            Activator.logException("Cannot calculate diagnostics", e);
+        }
+    }
+}

--- a/jakarta-eclipse/org.eclipse.lsp4jakarta.core/src/org/jakarta/jdt/cdi/ManagedBeanQuickFix.java
+++ b/jakarta-eclipse/org.eclipse.lsp4jakarta.core/src/org/jakarta/jdt/cdi/ManagedBeanQuickFix.java
@@ -1,0 +1,84 @@
+/*******************************************************************************
+* Copyright (c) 2020 Red Hat Inc. and others.
+*
+* This program and the accompanying materials are made available under the
+* terms of the Eclipse Public License v. 2.0 which is available at
+* http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+* which is available at https://www.apache.org/licenses/LICENSE-2.0.
+*
+* SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+*
+* Contributors:
+*     Hani Damlaj
+*******************************************************************************/
+
+package org.jakarta.jdt.cdi;
+
+import java.text.MessageFormat;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.jdt.core.dom.ASTNode;
+import org.eclipse.jdt.core.dom.CompilationUnit;
+import org.eclipse.jdt.core.dom.IBinding;
+import org.eclipse.jdt.core.dom.ITypeBinding;
+import org.eclipse.jdt.internal.corext.dom.Bindings;
+import org.eclipse.jdt.internal.core.manipulation.util.BasicElementLabels;
+import org.eclipse.lsp4j.CodeAction;
+import org.eclipse.lsp4j.Diagnostic;
+import org.jakarta.codeAction.IJavaCodeActionParticipant;
+import org.jakarta.codeAction.JavaCodeActionContext;
+import org.jakarta.codeAction.proposal.ChangeCorrectionProposal;
+import org.jakarta.codeAction.proposal.ExtendClassProposal;
+import org.jakarta.codeAction.proposal.ReplaceAnnotationProposal;
+import org.jakarta.jdt.servlet.InsertAnnotationMissingQuickFix;
+
+import static org.jakarta.jdt.cdi.ManagedBeanConstants.*;
+
+public class ManagedBeanQuickFix extends InsertAnnotationMissingQuickFix {
+    public ManagedBeanQuickFix() {
+        super("jakarta.enterprise.context.Dependent");
+    }
+
+    private static final String[] REMOVE_ANNOTATION_NAMES = new ArrayList<>(SCOPES).toArray(new String[SCOPES.size()]);
+
+    @Override
+    protected void insertAnnotations(Diagnostic diagnostic, JavaCodeActionContext context, IBinding parentType,
+            List<CodeAction> codeActions) throws CoreException {
+        String[] annotations = getAnnotations();
+        for (String annotation : annotations) {
+            insertAndReplaceAnnotation(diagnostic, context, parentType, codeActions, annotation);
+        }
+    }
+
+    private static void insertAndReplaceAnnotation(Diagnostic diagnostic, JavaCodeActionContext context,
+            IBinding parentType, List<CodeAction> codeActions, String annotation) throws CoreException {
+        // Diagnostic is reported on the variable declaration, however the
+        // annotations that need to be replaced are on the type declaration (class
+        // definition) containing the variable declaration. We retrieve the type
+        // declaration container here.
+        ASTNode parentNode = context.getASTRoot().findDeclaringNode(parentType);
+        IBinding classBinding = getBinding(parentNode);
+
+        // Insert the annotation and the proper import by using JDT Core Manipulation
+        // API
+        String name = getLabel(annotation);
+        ChangeCorrectionProposal proposal = new ReplaceAnnotationProposal(name, context.getCompilationUnit(),
+                context.getASTRoot(), classBinding, 0, annotation, REMOVE_ANNOTATION_NAMES);
+        // Convert the proposal to LSP4J CodeAction
+        CodeAction codeAction = context.convertToCodeAction(proposal, diagnostic);
+        if (codeAction != null) {
+            codeActions.add(codeAction);
+        }
+    }
+
+    private static String getLabel(String annotation) {
+        StringBuilder name = new StringBuilder("Replace current scope with ");
+        String annotationName = annotation.substring(annotation.lastIndexOf('.') + 1, annotation.length());
+        name.append("@");
+        name.append(annotationName);
+        return name.toString();
+    }
+}

--- a/jakarta-eclipse/org.eclipse.lsp4jakarta.core/src/org/jakarta/jdt/servlet/InsertAnnotationMissingQuickFix.java
+++ b/jakarta-eclipse/org.eclipse.lsp4jakarta.core/src/org/jakarta/jdt/servlet/InsertAnnotationMissingQuickFix.java
@@ -81,7 +81,7 @@ public class InsertAnnotationMissingQuickFix implements IJavaCodeActionParticipa
         return null;
     }
 
-    protected IBinding getBinding(ASTNode node) {
+    protected static IBinding getBinding(ASTNode node) {
         if (node.getParent() instanceof VariableDeclarationFragment) {
             VariableDeclarationFragment fragment = (VariableDeclarationFragment) node.getParent();
             return ((VariableDeclarationFragment) node.getParent()).resolveBinding();

--- a/jakarta-eclipse/org.eclipse.lsp4jakarta.tests/projects/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/cdi/ManagedBean.java
+++ b/jakarta-eclipse/org.eclipse.lsp4jakarta.tests/projects/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/cdi/ManagedBean.java
@@ -1,0 +1,8 @@
+package io.openliberty.sample.jakarta.cdi;
+
+import javax.enterprise.context.*;
+
+@RequestScoped
+public class ManagedBean {
+	public int a;
+}

--- a/jakarta-eclipse/org.eclipse.lsp4jakarta.tests/projects/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/cdi/ManagedBean.java
+++ b/jakarta-eclipse/org.eclipse.lsp4jakarta.tests/projects/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/cdi/ManagedBean.java
@@ -1,6 +1,6 @@
 package io.openliberty.sample.jakarta.cdi;
 
-import javax.enterprise.context.*;
+import jakarta.exterprise.context.*;
 
 @RequestScoped
 public class ManagedBean {

--- a/jakarta-eclipse/org.eclipse.lsp4jakarta.tests/src/main/java/org/eclipse/lsp4jakarta/jdt/cdi/ManagedBeanTest.java
+++ b/jakarta-eclipse/org.eclipse.lsp4jakarta.tests/src/main/java/org/eclipse/lsp4jakarta/jdt/cdi/ManagedBeanTest.java
@@ -32,12 +32,18 @@ public class ManagedBeanTest extends BaseJakartaTest {
         JakartaDiagnosticsParams diagnosticsParams = new JakartaDiagnosticsParams();
         diagnosticsParams.setUris(Arrays.asList(uri));
 
-        // expected
+        // test expected diagnostic
         Diagnostic d = d(6, 12, 13,
                 "A managed bean with a non-static public field must not declare any scope other than @Dependent",
                 DiagnosticSeverity.Error, "jakarta-cdi", "InvalidManagedBeanAnnotation");
 
         assertJavaDiagnostics(diagnosticsParams, JDT_UTILS, d);
+        
+        // test expected quick-fix      
+        JakartaJavaCodeActionParams codeActionParams = createCodeActionParams(uri, d);
+        TextEdit te = te(2, 0, 5, 0, "import jakarta.enterprise.context.Dependent;\nimport jakarta.exterprise.context.*;\n\n@Dependent\n");
+        CodeAction ca = ca(uri, "Replace current scope with @Dependent", d, te);
+        assertJavaCodeAction(codeActionParams, JDT_UTILS, ca);
     }
 
 }

--- a/jakarta-eclipse/org.eclipse.lsp4jakarta.tests/src/main/java/org/eclipse/lsp4jakarta/jdt/cdi/ManagedBeanTest.java
+++ b/jakarta-eclipse/org.eclipse.lsp4jakarta.tests/src/main/java/org/eclipse/lsp4jakarta/jdt/cdi/ManagedBeanTest.java
@@ -1,0 +1,43 @@
+package org.eclipse.lsp4jakarta.jdt.cdi;
+
+import static org.eclipse.lsp4jakarta.jdt.core.JakartaForJavaAssert.*;
+
+import java.util.Arrays;
+
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.runtime.Path;
+import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.lsp4j.CodeAction;
+import org.eclipse.lsp4j.Diagnostic;
+import org.eclipse.lsp4j.DiagnosticSeverity;
+import org.eclipse.lsp4j.TextEdit;
+import org.eclipse.lsp4jakarta.jdt.core.BaseJakartaTest;
+import org.jakarta.jdt.JDTUtils;
+import org.junit.Test;
+
+import io.microshed.jakartals.commons.JakartaDiagnosticsParams;
+import io.microshed.jakartals.commons.JakartaJavaCodeActionParams;
+
+public class ManagedBeanTest extends BaseJakartaTest {
+
+    protected static JDTUtils JDT_UTILS = new JDTUtils();
+
+    @Test
+    public void managedBeanAnnotations() throws Exception {
+        IJavaProject javaProject = loadJavaProject("jakarta-samples", "");
+        IFile javaFile = javaProject.getProject()
+                .getFile(new Path("src/main/java/io/openliberty/sample/jakarta/cdi/ManagedBean.java"));
+        String uri = javaFile.getLocation().toFile().toURI().toString();
+
+        JakartaDiagnosticsParams diagnosticsParams = new JakartaDiagnosticsParams();
+        diagnosticsParams.setUris(Arrays.asList(uri));
+
+        // expected
+        Diagnostic d = d(6, 12, 13,
+                "A managed bean with a non-static public field must not declare any scope other than @Dependent",
+                DiagnosticSeverity.Error, "jakarta-cdi", null);
+
+        assertJavaDiagnostics(diagnosticsParams, JDT_UTILS, d);
+    }
+
+}

--- a/jakarta-eclipse/org.eclipse.lsp4jakarta.tests/src/main/java/org/eclipse/lsp4jakarta/jdt/cdi/ManagedBeanTest.java
+++ b/jakarta-eclipse/org.eclipse.lsp4jakarta.tests/src/main/java/org/eclipse/lsp4jakarta/jdt/cdi/ManagedBeanTest.java
@@ -24,7 +24,7 @@ public class ManagedBeanTest extends BaseJakartaTest {
 
     @Test
     public void managedBeanAnnotations() throws Exception {
-        IJavaProject javaProject = loadJavaProject("jakarta-samples", "");
+        IJavaProject javaProject = loadJavaProject("jakarta-sample", "");
         IFile javaFile = javaProject.getProject()
                 .getFile(new Path("src/main/java/io/openliberty/sample/jakarta/cdi/ManagedBean.java"));
         String uri = javaFile.getLocation().toFile().toURI().toString();
@@ -35,7 +35,7 @@ public class ManagedBeanTest extends BaseJakartaTest {
         // expected
         Diagnostic d = d(6, 12, 13,
                 "A managed bean with a non-static public field must not declare any scope other than @Dependent",
-                DiagnosticSeverity.Error, "jakarta-cdi", null);
+                DiagnosticSeverity.Error, "jakarta-cdi", "InvalidManagedBeanAnnotation");
 
         assertJavaDiagnostics(diagnosticsParams, JDT_UTILS, d);
     }


### PR DESCRIPTION
Fixes #81

"If a managed bean has a non-static public field, it must have scope @Dependent. If a managed bean with a non-static public field declares any scope other than @Dependent, the container automatically detects the problem and treats it as a definition error." [Managed Bean Spec](https://jakarta.ee/specifications/cdi/2.0/cdi-spec-2.0.html#managed_beans)

- Annotated "@Dependent" with non-static public field(s); no errors.
<img width="1552" alt="depedentscope_suc" src="https://user-images.githubusercontent.com/22159422/106206442-175aa980-618e-11eb-9028-d5a60f630f52.png">

- Annotated "@Dependent" & "@ApplicationScoped" with non-static public field(s); shows errors.
<img width="1552" alt="dependentscope_err" src="https://user-images.githubusercontent.com/22159422/106206557-4a04a200-618e-11eb-9243-858ce0d26c56.png">

- Annotated "@ApplicationScoped" with non-static public field(s); shows errors.
<img width="1552" alt="applicationscope_err" src="https://user-images.githubusercontent.com/22159422/106206644-6ef91500-618e-11eb-9500-401bbb31bac0.png">

- Annotated "@ApplicationScoped" with **static** public field(s); no errors;
<img width="1552" alt="applicationscope_suc" src="https://user-images.githubusercontent.com/22159422/106206617-64d71680-618e-11eb-8972-33be25ec594e.png">

- Currently no logic implemented to recognise a managed bean other than annotations. Specifically, we don't detect managed beans according to the spec found here: [What classes are beans?](https://jakarta.ee/specifications/cdi/2.0/cdi-spec-2.0.html#what_classes_are_beans) 

When the diagnostic above appears, we suggest a quick-fix to replace the incorrect annotation with "Dependent".

-  Suggested quick-fix
<img width="1552" alt="quickfix_availability" src="https://user-images.githubusercontent.com/22159422/108426617-f247dc80-7209-11eb-8115-5b3594e121a9.png">

- Resulting code after quick-fix code action
<img width="1552" alt="quickfix_result" src="https://user-images.githubusercontent.com/22159422/108426686-0ab7f700-720a-11eb-834b-5c2b3948323e.png">