### PR TITLE
95 jsonbcreator quickfix

### DIFF
--- a/jakarta-eclipse/org.eclipse.lsp4jakarta.core/src/org/jakarta/codeAction/CodeActionHandler.java
+++ b/jakarta-eclipse/org.eclipse.lsp4jakarta.core/src/org/jakarta/codeAction/CodeActionHandler.java
@@ -35,6 +35,8 @@ import org.jakarta.jdt.persistence.PersistenceConstants;
 import org.jakarta.jdt.persistence.PersistenceEntityQuickFix;
 import org.jakarta.jdt.jax_rs.Jax_RSConstants;
 import org.jakarta.jdt.jax_rs.ResourceMethodQuickFix;
+import org.jakarta.jdt.jsonb.JsonbAnnotationQuickFix;
+import org.jakarta.jdt.jsonb.JsonbConstants;
 import org.jakarta.jdt.cdi.ConflictProducesInjectQuickFix;
 import org.jakarta.jdt.cdi.ManagedBeanConstants;
 import org.jakarta.jdt.cdi.ManagedBeanConstructorQuickFix;
@@ -90,7 +92,7 @@ public class CodeActionHandler {
             PersistenceEntityQuickFix PersistenceEntityQuickFix = new PersistenceEntityQuickFix();
             ConflictProducesInjectQuickFix ConflictProducesInjectQuickFix = new ConflictProducesInjectQuickFix();
             ManagedBeanConstructorQuickFix ManagedBeanConstructorQuickFix = new ManagedBeanConstructorQuickFix();
-
+            JsonbAnnotationQuickFix JsonbAnnotationQuickFix = new JsonbAnnotationQuickFix();
             for (Diagnostic diagnostic : params.getContext().getDiagnostics()) {
                 try {
                     if (diagnostic.getCode().getLeft().equals(ServletConstants.DIAGNOSTIC_CODE)) {
@@ -138,6 +140,9 @@ public class CodeActionHandler {
                     }
                     if(diagnostic.getCode().getLeft().equals(ManagedBeanConstants.CONSTRUCTOR_DIAGNOSTIC_CODE)) {
                     	codeActions.addAll(ManagedBeanConstructorQuickFix.getCodeActions(context, diagnostic, monitor));
+                    }
+                    if(diagnostic.getCode().getLeft().equals(JsonbConstants.DIAGNOSTIC_CODE_ANNOTATION)) {
+                        codeActions.addAll(JsonbAnnotationQuickFix.getCodeActions(context, diagnostic, monitor));
                     }
                 } catch (CoreException e) {
                     e.printStackTrace();

--- a/jakarta-eclipse/org.eclipse.lsp4jakarta.core/src/org/jakarta/codeAction/proposal/quickfix/RemoveAnnotationConflictQuickFix.java
+++ b/jakarta-eclipse/org.eclipse.lsp4jakarta.core/src/org/jakarta/codeAction/proposal/quickfix/RemoveAnnotationConflictQuickFix.java
@@ -130,6 +130,7 @@ public class RemoveAnnotationConflictQuickFix implements IJavaCodeActionParticip
             name.append("@");
             name.append(annotationName);
         }
+        name.append(" annotation");
         return name.toString();
     }
 }

--- a/jakarta-eclipse/org.eclipse.lsp4jakarta.core/src/org/jakarta/codeAction/proposal/quickfix/RemoveAnnotationConflictQuickFix.java
+++ b/jakarta-eclipse/org.eclipse.lsp4jakarta.core/src/org/jakarta/codeAction/proposal/quickfix/RemoveAnnotationConflictQuickFix.java
@@ -130,7 +130,6 @@ public class RemoveAnnotationConflictQuickFix implements IJavaCodeActionParticip
             name.append("@");
             name.append(annotationName);
         }
-        name.append(" annotation");
         return name.toString();
     }
 }

--- a/jakarta-eclipse/org.eclipse.lsp4jakarta.core/src/org/jakarta/jdt/jsonb/JsonbAnnotationQuickFix.java
+++ b/jakarta-eclipse/org.eclipse.lsp4jakarta.core/src/org/jakarta/jdt/jsonb/JsonbAnnotationQuickFix.java
@@ -1,0 +1,28 @@
+/*******************************************************************************
+* Copyright (c) 2021 IBM Corporation and others.
+*
+* This program and the accompanying materials are made available under the
+* terms of the Eclipse Public License v. 2.0 which is available at
+* http://www.eclipse.org/legal/epl-2.0.
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*     IBM Corporation - initial API and implementation
+*******************************************************************************/
+package org.jakarta.jdt.jsonb;
+
+import org.jakarta.codeAction.proposal.quickfix.RemoveAnnotationConflictQuickFix;
+
+/**
+ * Quick fix for removing additional @JsonbCreator annotations when more than
+ * one occur in a class
+ * 
+ * @author Leslie Dawson
+ *
+ */
+public class JsonbAnnotationQuickFix extends RemoveAnnotationConflictQuickFix {
+    public JsonbAnnotationQuickFix() {
+        super("jakarta.json.bind.annotation.JsonbCreator");
+    }
+}

--- a/jakarta-eclipse/org.eclipse.lsp4jakarta.core/src/org/jakarta/jdt/jsonb/JsonbConstants.java
+++ b/jakarta-eclipse/org.eclipse.lsp4jakarta.core/src/org/jakarta/jdt/jsonb/JsonbConstants.java
@@ -1,12 +1,15 @@
 package org.jakarta.jdt.jsonb;
 
 public class JsonbConstants {
-
+    
+    /* Source */
     public static final String DIAGNOSTIC_SOURCE = "jakarta-jsonb";
 
-    public static final String JSONB_CREATOR = "JsonbCreator";
-
-    public static final String ERROR_MESSAGE = "Only one constructor or static factory method can be annotated with @JsonbCreator in a given class.";
+    /* Code */
+    public static final String DIAGNOSTIC_CODE_ANNOTATION = "MultipleJsonbCreatorAnnotations";
     
+    /* Annotation Constants */
+    public static final String JSONB_CREATOR = "JsonbCreator";
+    public static final String ERROR_MESSAGE = "Only one constructor or static factory method can be annotated with @JsonbCreator in a given class.";
     public static final int MAX_METHOD_WITH_JSONBCREATOR = 1;
 }

--- a/jakarta-eclipse/org.eclipse.lsp4jakarta.core/src/org/jakarta/jdt/jsonb/JsonbCreatorDiagnosticsCollector.java
+++ b/jakarta-eclipse/org.eclipse.lsp4jakarta.core/src/org/jakarta/jdt/jsonb/JsonbCreatorDiagnosticsCollector.java
@@ -69,7 +69,6 @@ public class JsonbCreatorDiagnosticsCollector implements DiagnosticsCollector {
 
                     for (IMethod method : methods) {
                         Diagnostic diagnostic = createDiagnosticBy(unit, method);
-                        diagnostic.setCode(JsonbConstants.DIAGNOSTIC_CODE_ANNOTATION);
                         diagnostics.add(diagnostic);
                     }
                 }
@@ -81,12 +80,13 @@ public class JsonbCreatorDiagnosticsCollector implements DiagnosticsCollector {
     }   
 
     private Diagnostic createDiagnosticBy(ICompilationUnit unit, IMethod method) throws JavaModelException {
-
         ISourceRange sourceRange = JDTUtils.getNameRange(method);
-
         Range range = JDTUtils.toRange(unit, sourceRange.getOffset(), sourceRange.getLength());
-
-        return new Diagnostic(range, JsonbConstants.ERROR_MESSAGE);
-
+        String message = JsonbConstants.ERROR_MESSAGE;
+        DiagnosticSeverity severity = DiagnosticSeverity.Error; 
+        String source = JsonbConstants.DIAGNOSTIC_SOURCE;
+        String code = JsonbConstants.DIAGNOSTIC_CODE_ANNOTATION;
+        
+        return new Diagnostic(range, message, severity, source, code);
     }
 }

--- a/jakarta-eclipse/org.eclipse.lsp4jakarta.core/src/org/jakarta/jdt/jsonb/JsonbCreatorDiagnosticsCollector.java
+++ b/jakarta-eclipse/org.eclipse.lsp4jakarta.core/src/org/jakarta/jdt/jsonb/JsonbCreatorDiagnosticsCollector.java
@@ -69,6 +69,7 @@ public class JsonbCreatorDiagnosticsCollector implements DiagnosticsCollector {
 
                     for (IMethod method : methods) {
                         Diagnostic diagnostic = createDiagnosticBy(unit, method);
+                        diagnostic.setCode(JsonbConstants.DIAGNOSTIC_CODE_ANNOTATION);
                         diagnostics.add(diagnostic);
                     }
                 }

--- a/jakarta-eclipse/org.eclipse.lsp4jakarta.tests/projects/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/jsonb/ExtraJsonbCreatorAnnotations.java
+++ b/jakarta-eclipse/org.eclipse.lsp4jakarta.tests/projects/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/jsonb/ExtraJsonbCreatorAnnotations.java
@@ -1,0 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2021 IBM Corporation and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.sample.jakarta.jsonb;
+
+import jakarta.json.bind.annotation.JsonbCreator;
+
+public class ExtraJsonbCreatorAnnotation {
+    @JsonbCreator
+    public ExtraJsonbCreatorAnnotation() {}
+    
+    @JsonbCreator
+    private static ExtraJsonbCreatorAnnotation factoryMethod() {
+        return null;
+    }
+}

--- a/jakarta-eclipse/org.eclipse.lsp4jakarta.tests/projects/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/jsonb/ExtraJsonbCreatorAnnotations.java
+++ b/jakarta-eclipse/org.eclipse.lsp4jakarta.tests/projects/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/jsonb/ExtraJsonbCreatorAnnotations.java
@@ -14,12 +14,12 @@ package io.openliberty.sample.jakarta.jsonb;
 
 import jakarta.json.bind.annotation.JsonbCreator;
 
-public class ExtraJsonbCreatorAnnotation {
+public class ExtraJsonbCreatorAnnotations {
     @JsonbCreator
-    public ExtraJsonbCreatorAnnotation() {}
+    public ExtraJsonbCreatorAnnotations() {}
     
     @JsonbCreator
-    private static ExtraJsonbCreatorAnnotation factoryMethod() {
+    private static ExtraJsonbCreatorAnnotations factoryMethod() {
         return null;
     }
 }

--- a/jakarta-eclipse/org.eclipse.lsp4jakarta.tests/src/main/java/org/eclipse/lsp4jakarta/jdt/jsonb/JsonbTest.java
+++ b/jakarta-eclipse/org.eclipse.lsp4jakarta.tests/src/main/java/org/eclipse/lsp4jakarta/jdt/jsonb/JsonbTest.java
@@ -49,11 +49,11 @@ public class JsonbTest extends BaseJakartaTest {
         JakartaDiagnosticsParams diagnosticsParams = new JakartaDiagnosticsParams();
         diagnosticsParams.setUris(Arrays.asList(uri));
 
-        Diagnostic d1 = d(18, 11, 38,
+        Diagnostic d1 = d(18, 11, 39,
                 "Only one constructor or static factory method can be annotated with @JsonbCreator in a given class.",
                 DiagnosticSeverity.Error, "jakarta-jsonb", "MultipleJsonbCreatorAnnotations");
         
-        Diagnostic d2 = d(21, 47, 60,
+        Diagnostic d2 = d(21, 48, 61,
                 "Only one constructor or static factory method can be annotated with @JsonbCreator in a given class.",
                 DiagnosticSeverity.Error, "jakarta-jsonb", "MultipleJsonbCreatorAnnotations");
 

--- a/jakarta-eclipse/org.eclipse.lsp4jakarta.tests/src/main/java/org/eclipse/lsp4jakarta/jdt/jsonb/JsonbTest.java
+++ b/jakarta-eclipse/org.eclipse.lsp4jakarta.tests/src/main/java/org/eclipse/lsp4jakarta/jdt/jsonb/JsonbTest.java
@@ -1,0 +1,75 @@
+/*******************************************************************************
+* Copyright (c) 2021 IBM Corporation and others.
+*
+* This program and the accompanying materials are made available under the
+* terms of the Eclipse Public License v. 2.0 which is available at
+* http://www.eclipse.org/legal/epl-2.0.
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*     IBM Corporation - initial API and implementation
+*******************************************************************************/
+package org.eclipse.lsp4jakarta.jdt.jsonb;
+
+import static org.eclipse.lsp4jakarta.jdt.core.JakartaForJavaAssert.assertJavaCodeAction;
+import static org.eclipse.lsp4jakarta.jdt.core.JakartaForJavaAssert.assertJavaDiagnostics;
+import static org.eclipse.lsp4jakarta.jdt.core.JakartaForJavaAssert.ca;
+import static org.eclipse.lsp4jakarta.jdt.core.JakartaForJavaAssert.createCodeActionParams;
+import static org.eclipse.lsp4jakarta.jdt.core.JakartaForJavaAssert.d;
+import static org.eclipse.lsp4jakarta.jdt.core.JakartaForJavaAssert.te;
+
+import java.util.Arrays;
+
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.runtime.Path;
+import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.lsp4j.CodeAction;
+import org.eclipse.lsp4j.Diagnostic;
+import org.eclipse.lsp4j.DiagnosticSeverity;
+import org.eclipse.lsp4j.TextEdit;
+import org.eclipse.lsp4jakarta.jdt.core.BaseJakartaTest;
+import org.jakarta.jdt.JDTUtils;
+import org.junit.Test;
+
+import io.microshed.jakartals.commons.JakartaDiagnosticsParams;
+import io.microshed.jakartals.commons.JakartaJavaCodeActionParams;
+
+public class JsonbTest extends BaseJakartaTest {
+    protected static JDTUtils JDT_UTILS = new JDTUtils();
+
+    @Test
+    public void deleteExtraJsonbCreatorAnnotation() throws Exception {
+        JDTUtils utils = JDT_UTILS;
+        IJavaProject javaProject = loadJavaProject("jakarta-sample", "");
+        IFile javaFile = javaProject.getProject().getFile(
+                new Path("src/main/java/io/openliberty/sample/jakarta/jsonb/ExtraJsonbCreatorAnnotations.java"));
+        String uri = javaFile.getLocation().toFile().toURI().toString();
+
+        JakartaDiagnosticsParams diagnosticsParams = new JakartaDiagnosticsParams();
+        diagnosticsParams.setUris(Arrays.asList(uri));
+
+        Diagnostic d1 = d(18, 11, 38,
+                "Only one constructor or static factory method can be annotated with @JsonbCreator in a given class.",
+                DiagnosticSeverity.Error, "jakarta-jsonb", "MultipleJsonbCreatorAnnotations");
+        
+        Diagnostic d2 = d(21, 47, 60,
+                "Only one constructor or static factory method can be annotated with @JsonbCreator in a given class.",
+                DiagnosticSeverity.Error, "jakarta-jsonb", "MultipleJsonbCreatorAnnotations");
+
+        assertJavaDiagnostics(diagnosticsParams, utils, d1, d2);
+
+        // test code actions
+        JakartaJavaCodeActionParams codeActionParams1 = createCodeActionParams(uri, d1);
+        TextEdit te1 = te(17, 4, 18, 4, "");
+        CodeAction ca1 = ca(uri, "Remove @JsonbCreator", d1, te1);
+        
+        assertJavaCodeAction(codeActionParams1, utils, ca1);
+
+        JakartaJavaCodeActionParams codeActionParams2 = createCodeActionParams(uri, d2);
+        TextEdit te2 = te(20, 4, 21, 4, "");
+        CodeAction ca2 = ca(uri, "Remove @JsonbCreator", d2, te2);
+
+        assertJavaCodeAction(codeActionParams2, utils, ca2);
+    }
+}


### PR DESCRIPTION
Fixes #95 

Added quickfix for jsonbcreator errors to add a "Remove annotation" quickfix to each jsonbcreator annotation (there should only be one)

Added a code, source, and severity to the diagnostic.

Also added tests for the diagnostic and quickfix