### PR TITLE
Declaring bean scope

### DIFF
--- a/jakarta-eclipse/org.eclipse.lsp4jakarta.core/src/org/jakarta/jdt/cdi/ManagedBeanConstants.java
+++ b/jakarta-eclipse/org.eclipse.lsp4jakarta.core/src/org/jakarta/jdt/cdi/ManagedBeanConstants.java
@@ -30,6 +30,7 @@ public class ManagedBeanConstants {
     
     public static final String DIAGNOSTIC_SOURCE = "jakarta-cdi";
     public static final String DIAGNOSTIC_CODE = "InvalidManagedBeanAnnotation";
+    public static final String DIAGNOSTIC_CODE_SCOPEDECL = "InvalidScopeDecl";
     public static final String DIAGNOSTIC_CODE_PRODUCES_INJECT = "RemoveProducesOrInject";
     
     public static final String CONSTRUCTOR_DIAGNOSTIC_CODE = "InvalidManagedBeanConstructor";

--- a/jakarta-eclipse/org.eclipse.lsp4jakarta.core/src/org/jakarta/jdt/cdi/Utils.java
+++ b/jakarta-eclipse/org.eclipse.lsp4jakarta.core/src/org/jakarta/jdt/cdi/Utils.java
@@ -1,5 +1,6 @@
 package org.jakarta.jdt.cdi;
 
+import org.eclipse.jdt.core.IAnnotatable;
 import org.eclipse.jdt.core.IType;
 
 import static org.jakarta.jdt.cdi.ManagedBeanConstants.*;
@@ -28,7 +29,7 @@ public class Utils {
      * @param type the type representing the class
      * @return list of recognised managed bean defining annotations.
      */
-    static List<String> getManagedBeanAnnotations(IType type) {
+    static List<String> getManagedBeanAnnotations(IAnnotatable type) {
         try {
             // Construct a stream of only the annotations applied to the type that are also
             // recognised managed bean annotations.

--- a/jakarta-eclipse/org.eclipse.lsp4jakarta.core/src/org/jakarta/jdt/cdi/Utils.java
+++ b/jakarta-eclipse/org.eclipse.lsp4jakarta.core/src/org/jakarta/jdt/cdi/Utils.java
@@ -19,7 +19,7 @@ public class Utils {
      * @return true if the class has a bean defining annotation.
      */
     static boolean isManagedBean(IType type) {
-        return getManagedBeanAnnotations(type).size() > 0;
+        return getScopeAnnotations(type).size() > 0;
     }
 
     /**
@@ -29,7 +29,7 @@ public class Utils {
      * @param type the type representing the class
      * @return list of recognised managed bean defining annotations.
      */
-    static List<String> getManagedBeanAnnotations(IAnnotatable type) {
+    static List<String> getScopeAnnotations(IAnnotatable type) {
         try {
             // Construct a stream of only the annotations applied to the type that are also
             // recognised managed bean annotations.

--- a/jakarta-eclipse/org.eclipse.lsp4jakarta.tests/projects/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/cdi/ManagedBean.java
+++ b/jakarta-eclipse/org.eclipse.lsp4jakarta.tests/projects/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/cdi/ManagedBean.java
@@ -11,6 +11,7 @@ import jakarta.enterprise.context.*;
 public class ManagedBean {
 	public int a;
 	
+	
 	public ManagedBean() {
 		this.a = 10;
 	}

--- a/jakarta-eclipse/org.eclipse.lsp4jakarta.tests/projects/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/cdi/ManagedBean.java
+++ b/jakarta-eclipse/org.eclipse.lsp4jakarta.tests/projects/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/cdi/ManagedBean.java
@@ -1,10 +1,5 @@
 package io.openliberty.sample.jakarta.cdi;
 
-import java.util.Collections;
-import java.util.List;
-
-import jakarta.enterprise.inject.Produces;
-
 import jakarta.enterprise.context.*;
 
 @RequestScoped
@@ -14,10 +9,5 @@ public class ManagedBean {
 	
 	public ManagedBean() {
 		this.a = 10;
-	}
-	
-	@Produces @ApplicationScoped @RequestScoped
-	public List<Integer> getAllProductIds() {
-		return Collections.emptyList();
 	}
 }

--- a/jakarta-eclipse/org.eclipse.lsp4jakarta.tests/projects/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/cdi/ManagedBean.java
+++ b/jakarta-eclipse/org.eclipse.lsp4jakarta.tests/projects/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/cdi/ManagedBean.java
@@ -1,6 +1,11 @@
 package io.openliberty.sample.jakarta.cdi;
 
-import jakarta.enterprise.context.RequestScoped;
+import java.util.Collections;
+import java.util.List;
+
+import jakarta.enterprise.inject.Produces;
+
+import jakarta.enterprise.context.*;
 
 @RequestScoped
 public class ManagedBean {
@@ -8,5 +13,10 @@ public class ManagedBean {
 	
 	public ManagedBean() {
 		this.a = 10;
+	}
+	
+	@Produces @ApplicationScoped @RequestScoped
+	public List<Integer> getAllProductIds() {
+		return Collections.emptyList();
 	}
 }

--- a/jakarta-eclipse/org.eclipse.lsp4jakarta.tests/projects/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/cdi/ScopeDeclaration.java
+++ b/jakarta-eclipse/org.eclipse.lsp4jakarta.tests/projects/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/cdi/ScopeDeclaration.java
@@ -1,0 +1,19 @@
+package io.openliberty.sample.jakarta.cdi;
+
+import java.util.Collections;
+import java.util.List;
+
+import jakarta.enterprise.inject.Produces;
+
+import jakarta.enterprise.context.*;
+
+@ApplicationScoped @RequestScoped
+public class ScopeDeclaration {
+    @Produces @ApplicationScoped @Dependent
+    private int n;
+    
+    @Produces @ApplicationScoped @RequestScoped
+    public List<Integer> getAllProductIds() {
+        return Collections.emptyList();
+    }
+}

--- a/jakarta-eclipse/org.eclipse.lsp4jakarta.tests/src/main/java/org/eclipse/lsp4jakarta/jdt/cdi/ManagedBeanTest.java
+++ b/jakarta-eclipse/org.eclipse.lsp4jakarta.tests/src/main/java/org/eclipse/lsp4jakarta/jdt/cdi/ManagedBeanTest.java
@@ -33,20 +33,41 @@ public class ManagedBeanTest extends BaseJakartaTest {
         diagnosticsParams.setUris(Arrays.asList(uri));
 
         // test expected diagnostic
-        Diagnostic d = d(11, 12, 13,
+        Diagnostic d = d(6, 12, 13,
                 "A managed bean with a non-static public field must not declare any scope other than @Dependent",
                 DiagnosticSeverity.Error, "jakarta-cdi", "InvalidManagedBeanAnnotation");
 
-        Diagnostic d2 = d(19, 22, 38, "A producer method may specify at most one scope type annotation.",
-                DiagnosticSeverity.Error, "jakarta-cdi", "InvalidScopeDecl");
-
-        assertJavaDiagnostics(diagnosticsParams, JDT_UTILS, d, d2);
+        assertJavaDiagnostics(diagnosticsParams, JDT_UTILS, d);
 
         // test expected quick-fix
         JakartaJavaCodeActionParams codeActionParams = createCodeActionParams(uri, d);
-        TextEdit te = te(9, 0, 10, 0, "@Dependent\n");
+        TextEdit te = te(4, 0, 5, 0, "@Dependent\n");
         CodeAction ca = ca(uri, "Replace current scope with @Dependent", d, te);
         assertJavaCodeAction(codeActionParams, JDT_UTILS, ca);
+    }
+    
+    @Test
+    public void scopeDeclaration() throws Exception {
+        IJavaProject javaProject = loadJavaProject("jakarta-sample", "");
+        IFile javaFile = javaProject.getProject()
+                .getFile(new Path("src/main/java/io/openliberty/sample/jakarta/cdi/ScopeDeclaration.java"));
+        String uri = javaFile.getLocation().toFile().toURI().toString();
+
+        JakartaDiagnosticsParams diagnosticsParams = new JakartaDiagnosticsParams();
+        diagnosticsParams.setUris(Arrays.asList(uri));
+
+        // test expected diagnostic
+        Diagnostic d1 = d(12, 16, 17,
+                "A producer field may specify at most one scope type annotation.",
+                DiagnosticSeverity.Error, "jakarta-cdi", "InvalidScopeDecl");
+
+        Diagnostic d2 = d(15, 25, 41, "A producer method may specify at most one scope type annotation.",
+                DiagnosticSeverity.Error, "jakarta-cdi", "InvalidScopeDecl");
+        
+        Diagnostic d3 = d(10, 13, 29, "A managed bean class may specify at most one scope type annotation.",
+                DiagnosticSeverity.Error, "jakarta-cdi", "InvalidScopeDecl");
+
+        assertJavaDiagnostics(diagnosticsParams, JDT_UTILS, d1, d2, d3);
     }
 
     @Test

--- a/jakarta-eclipse/org.eclipse.lsp4jakarta.tests/src/main/java/org/eclipse/lsp4jakarta/jdt/cdi/ManagedBeanTest.java
+++ b/jakarta-eclipse/org.eclipse.lsp4jakarta.tests/src/main/java/org/eclipse/lsp4jakarta/jdt/cdi/ManagedBeanTest.java
@@ -33,19 +33,23 @@ public class ManagedBeanTest extends BaseJakartaTest {
         diagnosticsParams.setUris(Arrays.asList(uri));
 
         // test expected diagnostic
-        Diagnostic d = d(6, 12, 13,
+        Diagnostic d = d(11, 12, 13,
                 "A managed bean with a non-static public field must not declare any scope other than @Dependent",
                 DiagnosticSeverity.Error, "jakarta-cdi", "InvalidManagedBeanAnnotation");
 
-        assertJavaDiagnostics(diagnosticsParams, JDT_UTILS, d);
-        
-        // test expected quick-fix      
+        Diagnostic d2 = d(18, 22, 38,
+                "A bean class or producer method or field may specify at most one scope type annotation.",
+                DiagnosticSeverity.Error, "jakarta-cdi", "InvalidManagedBeanAnnotation");
+
+        assertJavaDiagnostics(diagnosticsParams, JDT_UTILS, d, d2);
+
+        // test expected quick-fix
         JakartaJavaCodeActionParams codeActionParams = createCodeActionParams(uri, d);
-        TextEdit te = te(2, 0, 5, 0, "import jakarta.enterprise.context.Dependent;\nimport jakarta.enterprise.context.RequestScoped;\n\n@Dependent\n");
+        TextEdit te = te(9, 0, 10, 0, "@Dependent\n");
         CodeAction ca = ca(uri, "Replace current scope with @Dependent", d, te);
         assertJavaCodeAction(codeActionParams, JDT_UTILS, ca);
     }
-    
+
     @Test
     public void producesAndInject() throws Exception {
         JDTUtils utils = JDT_UTILS;
@@ -53,20 +57,18 @@ public class ManagedBeanTest extends BaseJakartaTest {
         IFile javaFile = javaProject.getProject()
                 .getFile(new Path("src/main/java/io/openliberty/sample/jakarta/cdi/ProducesAndInjectTogether.java"));
         String uri = javaFile.getLocation().toFile().toURI().toString();
-        
+
         JakartaDiagnosticsParams diagnosticsParams = new JakartaDiagnosticsParams();
         diagnosticsParams.setUris(Arrays.asList(uri));
-        
-        Diagnostic d1 = d(16, 18, 23,
-                "@Produces and @Inject annotations cannot be used on the same field or property",
+
+        Diagnostic d1 = d(16, 18, 23, "@Produces and @Inject annotations cannot be used on the same field or property",
                 DiagnosticSeverity.Error, "jakarta-cdi", "RemoveProducesOrInject");
 
-        Diagnostic d2 = d(11, 19, 27,
-                "@Produces and @Inject annotations cannot be used on the same field or property",
+        Diagnostic d2 = d(11, 19, 27, "@Produces and @Inject annotations cannot be used on the same field or property",
                 DiagnosticSeverity.Error, "jakarta-cdi", "RemoveProducesOrInject");
 
         assertJavaDiagnostics(diagnosticsParams, utils, d1, d2);
-        
+
         JakartaJavaCodeActionParams codeActionParams1 = createCodeActionParams(uri, d1);
 
         TextEdit te1 = te(14, 4, 15, 4, "");
@@ -75,7 +77,7 @@ public class ManagedBeanTest extends BaseJakartaTest {
         CodeAction ca2 = ca(uri, "Remove @Inject", d1, te2);
 
         assertJavaCodeAction(codeActionParams1, utils, ca1, ca2);
-        
+
         JakartaJavaCodeActionParams codeActionParams2 = createCodeActionParams(uri, d2);
 
         TextEdit te3 = te(9, 4, 10, 4, "");
@@ -90,84 +92,83 @@ public class ManagedBeanTest extends BaseJakartaTest {
     public void injectAndDisposesObservesObservesAsync() throws Exception {
         JDTUtils utils = JDT_UTILS;
         IJavaProject javaProject = loadJavaProject("jakarta-sample", "");
-        IFile javaFile = javaProject.getProject()
-                .getFile(new Path("src/main/java/io/openliberty/sample/jakarta/cdi/InjectAndDisposesObservesObservesAsync.java"));
+        IFile javaFile = javaProject.getProject().getFile(new Path(
+                "src/main/java/io/openliberty/sample/jakarta/cdi/InjectAndDisposesObservesObservesAsync.java"));
         String uri = javaFile.getLocation().toFile().toURI().toString();
-        
+
         JakartaDiagnosticsParams diagnosticsParams = new JakartaDiagnosticsParams();
         diagnosticsParams.setUris(Arrays.asList(uri));
-        
+
         Diagnostic d1 = d(10, 18, 31,
                 "A bean constructor or a method annotated with @Inject cannot have parameter(s) annotated with @Disposes",
                 DiagnosticSeverity.Error, "jakarta-cdi", "RemoveInjectOrConflictedAnnotations");
-        
+
         Diagnostic d2 = d(16, 18, 31,
                 "A bean constructor or a method annotated with @Inject cannot have parameter(s) annotated with @Observes",
                 DiagnosticSeverity.Error, "jakarta-cdi", "RemoveInjectOrConflictedAnnotations");
-        
+
         Diagnostic d3 = d(22, 18, 36,
                 "A bean constructor or a method annotated with @Inject cannot have parameter(s) annotated with @ObservesAsync",
                 DiagnosticSeverity.Error, "jakarta-cdi", "RemoveInjectOrConflictedAnnotations");
-        
+
         Diagnostic d4 = d(28, 18, 39,
                 "A bean constructor or a method annotated with @Inject cannot have parameter(s) annotated with @Disposes, @Observes",
                 DiagnosticSeverity.Error, "jakarta-cdi", "RemoveInjectOrConflictedAnnotations");
-        
+
         Diagnostic d5 = d(34, 18, 44,
                 "A bean constructor or a method annotated with @Inject cannot have parameter(s) annotated with @Observes, @ObservesAsync",
                 DiagnosticSeverity.Error, "jakarta-cdi", "RemoveInjectOrConflictedAnnotations");
-        
+
         Diagnostic d6 = d(40, 18, 44,
                 "A bean constructor or a method annotated with @Inject cannot have parameter(s) annotated with @Disposes, @ObservesAsync",
                 DiagnosticSeverity.Error, "jakarta-cdi", "RemoveInjectOrConflictedAnnotations");
-        
+
         Diagnostic d7 = d(46, 18, 52,
                 "A bean constructor or a method annotated with @Inject cannot have parameter(s) annotated with @Disposes, @Observes, @ObservesAsync",
                 DiagnosticSeverity.Error, "jakarta-cdi", "RemoveInjectOrConflictedAnnotations");
-        
+
         assertJavaDiagnostics(diagnosticsParams, utils, d1, d2, d3, d4, d5, d6, d7);
     }
-    
-    
+
     @Test
     public void producesAndDisposesObservesObservesAsync() throws Exception {
         JDTUtils utils = JDT_UTILS;
         IJavaProject javaProject = loadJavaProject("jakarta-sample", "");
-        IFile javaFile = javaProject.getProject()
-                .getFile(new Path("src/main/java/io/openliberty/sample/jakarta/cdi/ProducesAndDisposesObservesObservesAsync.java"));
+        IFile javaFile = javaProject.getProject().getFile(new Path(
+                "src/main/java/io/openliberty/sample/jakarta/cdi/ProducesAndDisposesObservesObservesAsync.java"));
         String uri = javaFile.getLocation().toFile().toURI().toString();
-        
+
         JakartaDiagnosticsParams diagnosticsParams = new JakartaDiagnosticsParams();
         diagnosticsParams.setUris(Arrays.asList(uri));
-        
+
         Diagnostic d1 = d(12, 18, 31,
                 "A bean constructor or a method annotated with @Produces cannot have parameter(s) annotated with @Disposes",
                 DiagnosticSeverity.Error, "jakarta-cdi", "RemoveProducesOrConflictedAnnotations");
-        
+
         Diagnostic d2 = d(18, 18, 31,
                 "A bean constructor or a method annotated with @Produces cannot have parameter(s) annotated with @Observes",
                 DiagnosticSeverity.Error, "jakarta-cdi", "RemoveProducesOrConflictedAnnotations");
-        
+
         Diagnostic d3 = d(24, 18, 36,
                 "A bean constructor or a method annotated with @Produces cannot have parameter(s) annotated with @ObservesAsync",
                 DiagnosticSeverity.Error, "jakarta-cdi", "RemoveProducesOrConflictedAnnotations");
-        
+
         Diagnostic d4 = d(30, 18, 39,
                 "A bean constructor or a method annotated with @Produces cannot have parameter(s) annotated with @Disposes, @Observes",
                 DiagnosticSeverity.Error, "jakarta-cdi", "RemoveProducesOrConflictedAnnotations");
-        
+
         Diagnostic d5 = d(36, 18, 44,
                 "A bean constructor or a method annotated with @Produces cannot have parameter(s) annotated with @Observes, @ObservesAsync",
                 DiagnosticSeverity.Error, "jakarta-cdi", "RemoveProducesOrConflictedAnnotations");
-        
+
         Diagnostic d6 = d(42, 18, 44,
                 "A bean constructor or a method annotated with @Produces cannot have parameter(s) annotated with @Disposes, @ObservesAsync",
                 DiagnosticSeverity.Error, "jakarta-cdi", "RemoveProducesOrConflictedAnnotations");
-        
+
         Diagnostic d7 = d(48, 18, 52,
                 "A bean constructor or a method annotated with @Produces cannot have parameter(s) annotated with @Disposes, @Observes, @ObservesAsync",
                 DiagnosticSeverity.Error, "jakarta-cdi", "RemoveProducesOrConflictedAnnotations");
-        
+
         assertJavaDiagnostics(diagnosticsParams, utils, d1, d2, d3, d4, d5, d6, d7);
     }
 }

--- a/jakarta-eclipse/org.eclipse.lsp4jakarta.tests/src/main/java/org/eclipse/lsp4jakarta/jdt/cdi/ManagedBeanTest.java
+++ b/jakarta-eclipse/org.eclipse.lsp4jakarta.tests/src/main/java/org/eclipse/lsp4jakarta/jdt/cdi/ManagedBeanTest.java
@@ -37,9 +37,8 @@ public class ManagedBeanTest extends BaseJakartaTest {
                 "A managed bean with a non-static public field must not declare any scope other than @Dependent",
                 DiagnosticSeverity.Error, "jakarta-cdi", "InvalidManagedBeanAnnotation");
 
-        Diagnostic d2 = d(18, 22, 38,
-                "A bean class or producer method or field may specify at most one scope type annotation.",
-                DiagnosticSeverity.Error, "jakarta-cdi", "InvalidManagedBeanAnnotation");
+        Diagnostic d2 = d(19, 22, 38, "A producer method may specify at most one scope type annotation.",
+                DiagnosticSeverity.Error, "jakarta-cdi", "InvalidScopeDecl");
 
         assertJavaDiagnostics(diagnosticsParams, JDT_UTILS, d, d2);
 


### PR DESCRIPTION
Fix issue #103 

From https://jakarta.ee/specifications/cdi/3.0/jakarta-cdi-spec-3.0.html#declaring_bean_scope:
"A bean class or producer method or field may specify at most one scope type annotation. If a bean class or producer method or field specifies multiple scope type annotations, the container automatically detects the problem and treats it as a definition error."

## Diagnostic
![diagnostic](https://user-images.githubusercontent.com/22159422/112240576-f1e29d00-8c1e-11eb-8d10-daddb23c3d7d.png)

## Test using ```assertDiagnostics(List<Diagnostic> actual, List<Diagnostic> expected)```
- Ordering of the diagnostic within the actual and expected lists shouldn't affect equality – added support for ordering the two lists by the start and end ranges before comparing for equality

previously, assertDiagnostics would report the following error for two lists of identical diagnostics (fields of the diagnostic for brevity) due to the ordering within the list:

```
Failures:
  ManagedBeanTest.producesAndInject:70 Unexpected diagnostics:
expected:<[Diagnostic [
  range = Range [
    start = Position [
      line = 16
      character = 18
    ]
    end = Position [
      line = 16
      character = 23
    ]
  ]
], Diagnostic [
  range = Range [
    start = Position [
      line = 11
      character = 19
    ]
    end = Position [
      line = 11
      character = 27
    ]
  ]
]]> but was:<[Diagnostic [
  range = Range [
    start = Position [
      line = 11
      character = 19
    ]
    end = Position [
      line = 11
      character = 27
    ]
  ]
], Diagnostic [
  range = Range [
    start = Position [
      line = 16
      character = 18
    ]
    end = Position [
      line = 16
      character = 23
    ]
  ]
]]>
```
