### PR TITLE
Add quick fixes to remove entity params in resource method

### DIFF
--- a/jakarta-eclipse/org.eclipse.lsp4jakarta.core/src/org/jakarta/codeAction/CodeActionHandler.java
+++ b/jakarta-eclipse/org.eclipse.lsp4jakarta.core/src/org/jakarta/codeAction/CodeActionHandler.java
@@ -37,7 +37,8 @@ import org.jakarta.jdt.persistence.PersistenceAnnotationQuickFix;
 import org.jakarta.jdt.persistence.PersistenceConstants;
 import org.jakarta.jdt.persistence.PersistenceEntityQuickFix;
 import org.jakarta.jdt.jax_rs.Jax_RSConstants;
-import org.jakarta.jdt.jax_rs.ResourceMethodQuickFix;
+import org.jakarta.jdt.jax_rs.NonPublicResourceMethodQuickFix;
+import org.jakarta.jdt.jax_rs.ResourceMethodMultipleEntityParamsQuickFix;
 import org.jakarta.jdt.jsonb.JsonbAnnotationQuickFix;
 import org.jakarta.jdt.jsonb.JsonbConstants;
 import org.jakarta.jdt.cdi.ConflictProducesInjectQuickFix;
@@ -88,7 +89,8 @@ public class CodeActionHandler {
             CompleteFilterAnnotationQuickFix CompleteFilterAnnotationQuickFix = new CompleteFilterAnnotationQuickFix();
             PersistenceAnnotationQuickFix PersistenceAnnotationQuickFix = new PersistenceAnnotationQuickFix();
             DeleteConflictMapKeyQuickFix DeleteConflictMapKeyQuickFix = new DeleteConflictMapKeyQuickFix();
-            ResourceMethodQuickFix ResourceMethodQuickFix = new ResourceMethodQuickFix();
+            NonPublicResourceMethodQuickFix NonPublicResourceMethodQuickFix = new NonPublicResourceMethodQuickFix();
+            ResourceMethodMultipleEntityParamsQuickFix ResourceMethodMultipleEntityParamsQuickFix = new ResourceMethodMultipleEntityParamsQuickFix();
             ManagedBeanQuickFix ManagedBeanQuickFix = new ManagedBeanQuickFix();
             PersistenceEntityQuickFix PersistenceEntityQuickFix = new PersistenceEntityQuickFix();
             ConflictProducesInjectQuickFix ConflictProducesInjectQuickFix = new ConflictProducesInjectQuickFix();
@@ -119,19 +121,27 @@ public class CodeActionHandler {
                                 .addAll(CompleteFilterAnnotationQuickFix.getCodeActions(context, diagnostic, monitor));
                     }
                     if (diagnostic.getCode().getLeft().equals(Jax_RSConstants.DIAGNOSTIC_CODE_NON_PUBLIC)) {
-                        codeActions.addAll(ResourceMethodQuickFix.getCodeActions(context, diagnostic, monitor));
+                        codeActions
+                                .addAll(NonPublicResourceMethodQuickFix.getCodeActions(context, diagnostic, monitor));
                     }
-                    if(diagnostic.getCode().getLeft().equals(PersistenceConstants.DIAGNOSTIC_CODE_MISSING_ATTRIBUTES)) {
-                    	codeActions.addAll(PersistenceAnnotationQuickFix.getCodeActions(context, diagnostic, monitor));
+                    if (diagnostic.getCode().getLeft().equals(Jax_RSConstants.DIAGNOSTIC_CODE_MULTIPLE_ENTITY_PARAMS)) {
+                        codeActions.addAll(ResourceMethodMultipleEntityParamsQuickFix.getCodeActions(context,
+                                diagnostic, monitor));
+                    }
+                    if (diagnostic.getCode().getLeft()
+                            .equals(PersistenceConstants.DIAGNOSTIC_CODE_MISSING_ATTRIBUTES)) {
+                        codeActions.addAll(PersistenceAnnotationQuickFix.getCodeActions(context, diagnostic, monitor));
                     }
                     if (diagnostic.getCode().getLeft()
                             .equals(PersistenceConstants.DIAGNOSTIC_CODE_INVALID_ANNOTATION)) {
                         codeActions.addAll(DeleteConflictMapKeyQuickFix.getCodeActions(context, diagnostic, monitor));
                     }
                     if (diagnostic.getCode().getLeft().equals(PersistenceConstants.DIAGNOSTIC_CODE_FINAL_METHODS)
-                            || diagnostic.getCode().getLeft().equals(PersistenceConstants.DIAGNOSTIC_CODE_FINAL_VARIABLES) 
+                            || diagnostic.getCode().getLeft()
+                                    .equals(PersistenceConstants.DIAGNOSTIC_CODE_FINAL_VARIABLES)
                             || diagnostic.getCode().getLeft().equals(PersistenceConstants.DIAGNOSTIC_CODE_FINAL_CLASS)
-                            || diagnostic.getCode().getLeft().equals(PersistenceConstants.DIAGNOSTIC_CODE_MISSING_EMPTY_CONSTRUCTOR)) {
+                            || diagnostic.getCode().getLeft()
+                                    .equals(PersistenceConstants.DIAGNOSTIC_CODE_MISSING_EMPTY_CONSTRUCTOR)) {
                         codeActions.addAll(PersistenceEntityQuickFix.getCodeActions(context, diagnostic, monitor));
                     }
                     if (diagnostic.getCode().getLeft().equals(ManagedBeanConstants.DIAGNOSTIC_CODE)) {
@@ -141,13 +151,14 @@ public class CodeActionHandler {
                         codeActions.addAll(ConflictProducesInjectQuickFix.getCodeActions(context, diagnostic, monitor));
                     }
                     if (diagnostic.getCode().getLeft().equals(BeanValidationConstants.DIAGNOSTIC_CODE_STATIC)
-                            || diagnostic.getCode().getLeft().equals(BeanValidationConstants.DIAGNOSTIC_CODE_INVALID_TYPE)) {
+                            || diagnostic.getCode().getLeft()
+                                    .equals(BeanValidationConstants.DIAGNOSTIC_CODE_INVALID_TYPE)) {
                         codeActions.addAll(BeanValidationQuickFix.getCodeActions(context, diagnostic, monitor));
                     }
-                    if(diagnostic.getCode().getLeft().equals(ManagedBeanConstants.CONSTRUCTOR_DIAGNOSTIC_CODE)) {
-                    	codeActions.addAll(ManagedBeanConstructorQuickFix.getCodeActions(context, diagnostic, monitor));
+                    if (diagnostic.getCode().getLeft().equals(ManagedBeanConstants.CONSTRUCTOR_DIAGNOSTIC_CODE)) {
+                        codeActions.addAll(ManagedBeanConstructorQuickFix.getCodeActions(context, diagnostic, monitor));
                     }
-                    if(diagnostic.getCode().getLeft().equals(JsonbConstants.DIAGNOSTIC_CODE_ANNOTATION)) {
+                    if (diagnostic.getCode().getLeft().equals(JsonbConstants.DIAGNOSTIC_CODE_ANNOTATION)) {
                         codeActions.addAll(JsonbAnnotationQuickFix.getCodeActions(context, diagnostic, monitor));
                     }
                 } catch (CoreException e) {

--- a/jakarta-eclipse/org.eclipse.lsp4jakarta.core/src/org/jakarta/codeAction/proposal/ModifyModifiersProposal.java
+++ b/jakarta-eclipse/org.eclipse.lsp4jakarta.core/src/org/jakarta/codeAction/proposal/ModifyModifiersProposal.java
@@ -39,12 +39,12 @@ import org.eclipse.lsp4j.CodeActionKind;
 
 /**
  * Code action proposal for changing the visibility modifier of a method, field, or type.
- * Used by JAX-RS ResourceMethodQuickFix.
+ * Used by JAX-RS NonPublicResourceMethodQuickFix.
  * 
  * @author  Matthew Shocrylas
  * @author  Leslie Dawson
  * @see     CodeActionHandler
- * @see     ResourceMethodQuickFix
+ * @see     NonPublicResourceMethodQuickFix
  * @see     PersistenceEntityQuickFix
  * 
  */

--- a/jakarta-eclipse/org.eclipse.lsp4jakarta.core/src/org/jakarta/codeAction/proposal/RemoveEntityParamsProposal.java
+++ b/jakarta-eclipse/org.eclipse.lsp4jakarta.core/src/org/jakarta/codeAction/proposal/RemoveEntityParamsProposal.java
@@ -1,0 +1,94 @@
+/*******************************************************************************
+ * Copyright (c) 2021 IBM Corporation, Bera Sogut and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation, Bera Sogut - initial API and implementation
+ *******************************************************************************/
+
+package org.jakarta.codeAction.proposal;
+
+import java.util.List;
+
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.dom.AST;
+import org.eclipse.jdt.core.dom.ASTNode;
+import org.eclipse.jdt.core.dom.CompilationUnit;
+import org.eclipse.jdt.core.dom.IBinding;
+import org.eclipse.jdt.core.dom.MethodDeclaration;
+import org.eclipse.jdt.core.dom.SingleVariableDeclaration;
+import org.eclipse.jdt.core.dom.rewrite.ASTRewrite;
+import org.eclipse.jdt.core.dom.rewrite.ListRewrite;
+import org.eclipse.jdt.internal.core.manipulation.dom.ASTResolving;
+import org.eclipse.lsp4j.CodeActionKind;
+
+/**
+ * Code action proposal for removing the entity parameters of a method except
+ * one. Used by JAX-RS ResourceMethodMultipleEntityParamsQuickFix.
+ *
+ * @author Bera Sogut
+ * @see CodeActionHandler
+ * @see ResourceMethodMultipleEntityParamsQuickFix
+ *
+ */
+public class RemoveEntityParamsProposal extends ChangeCorrectionProposal {
+
+    private final CompilationUnit invocationNode;
+    private final IBinding binding;
+
+    // the entity parameters of the function
+    private final List<SingleVariableDeclaration> entityParams;
+
+    // the entity parameter to keep
+    private final SingleVariableDeclaration entityParamToKeep;
+
+    /**
+     * Constructor for RemoveEntityParamsProposal that accepts the entity parameters
+     * of the function and the entity parameter to keep.
+     *
+     * @param entityParams      the entity parameters of the function
+     * @param entityParamToKeep the entity parameter to keep
+     */
+    public RemoveEntityParamsProposal(String label, ICompilationUnit targetCU, CompilationUnit invocationNode,
+            IBinding binding, int relevance, List<SingleVariableDeclaration> entityParams,
+            SingleVariableDeclaration entityParamToKeep) {
+        super(label, CodeActionKind.QuickFix, targetCU, null, relevance);
+        this.invocationNode = invocationNode;
+        this.binding = binding;
+        this.entityParams = entityParams;
+        this.entityParamToKeep = entityParamToKeep;
+    }
+
+    @Override
+    protected ASTRewrite getRewrite() throws CoreException {
+        ASTNode declNode = null;
+        ASTNode boundNode = invocationNode.findDeclaringNode(binding);
+
+        if (boundNode != null) {
+            declNode = boundNode;
+        } else {
+            CompilationUnit newRoot = ASTResolving.createQuickFixAST(getCompilationUnit(), null);
+            declNode = newRoot.findDeclaringNode(binding.getKey());
+        }
+
+        AST ast = declNode.getAST();
+        ASTRewrite rewrite = ASTRewrite.create(ast);
+
+        ListRewrite parametersList = rewrite.getListRewrite(declNode, MethodDeclaration.PARAMETERS_PROPERTY);
+
+        // remove all entity parameters except the entity parameter to keep
+        for (SingleVariableDeclaration entityParam : entityParams) {
+            if (!entityParam.equals(entityParamToKeep)) {
+                parametersList.remove(entityParam, null);
+            }
+        }
+
+        return rewrite;
+    }
+}

--- a/jakarta-eclipse/org.eclipse.lsp4jakarta.core/src/org/jakarta/codeAction/proposal/RemoveParamsProposal.java
+++ b/jakarta-eclipse/org.eclipse.lsp4jakarta.core/src/org/jakarta/codeAction/proposal/RemoveParamsProposal.java
@@ -37,32 +37,32 @@ import org.eclipse.lsp4j.CodeActionKind;
  * @see ResourceMethodMultipleEntityParamsQuickFix
  *
  */
-public class RemoveEntityParamsProposal extends ChangeCorrectionProposal {
+public class RemoveParamsProposal extends ChangeCorrectionProposal {
 
     private final CompilationUnit invocationNode;
     private final IBinding binding;
 
-    // the entity parameters of the function
-    private final List<SingleVariableDeclaration> entityParams;
+    // parameters to remove
+    private final List<SingleVariableDeclaration> params;
 
-    // the entity parameter to keep
-    private final SingleVariableDeclaration entityParamToKeep;
+    // parameter to keep
+    private final SingleVariableDeclaration paramToKeep;
 
     /**
-     * Constructor for RemoveEntityParamsProposal that accepts the entity parameters
-     * of the function and the entity parameter to keep.
+     * Constructor for RemoveParamsProposal that accepts parameters to remove and a
+     * parameter to keep.
      *
-     * @param entityParams      the entity parameters of the function
-     * @param entityParamToKeep the entity parameter to keep
+     * @param params      the parameters of the function to remove
+     * @param paramToKeep the parameter of the function to keep
      */
-    public RemoveEntityParamsProposal(String label, ICompilationUnit targetCU, CompilationUnit invocationNode,
-            IBinding binding, int relevance, List<SingleVariableDeclaration> entityParams,
-            SingleVariableDeclaration entityParamToKeep) {
+    public RemoveParamsProposal(String label, ICompilationUnit targetCU, CompilationUnit invocationNode,
+            IBinding binding, int relevance, List<SingleVariableDeclaration> params,
+            SingleVariableDeclaration paramToKeep) {
         super(label, CodeActionKind.QuickFix, targetCU, null, relevance);
         this.invocationNode = invocationNode;
         this.binding = binding;
-        this.entityParams = entityParams;
-        this.entityParamToKeep = entityParamToKeep;
+        this.params = params;
+        this.paramToKeep = paramToKeep;
     }
 
     @Override
@@ -82,10 +82,10 @@ public class RemoveEntityParamsProposal extends ChangeCorrectionProposal {
 
         ListRewrite parametersList = rewrite.getListRewrite(declNode, MethodDeclaration.PARAMETERS_PROPERTY);
 
-        // remove all entity parameters except the entity parameter to keep
-        for (SingleVariableDeclaration entityParam : entityParams) {
-            if (!entityParam.equals(entityParamToKeep)) {
-                parametersList.remove(entityParam, null);
+        // remove the parameters except the parameter to keep
+        for (SingleVariableDeclaration param : params) {
+            if (!param.equals(paramToKeep)) {
+                parametersList.remove(param, null);
             }
         }
 

--- a/jakarta-eclipse/org.eclipse.lsp4jakarta.core/src/org/jakarta/codeAction/proposal/RemoveParamsProposal.java
+++ b/jakarta-eclipse/org.eclipse.lsp4jakarta.core/src/org/jakarta/codeAction/proposal/RemoveParamsProposal.java
@@ -29,8 +29,8 @@ import org.eclipse.jdt.internal.core.manipulation.dom.ASTResolving;
 import org.eclipse.lsp4j.CodeActionKind;
 
 /**
- * Code action proposal for removing the entity parameters of a method except
- * one. Used by JAX-RS ResourceMethodMultipleEntityParamsQuickFix.
+ * Code action proposal for removing parameters of a method except one. Used by
+ * JAX-RS ResourceMethodMultipleEntityParamsQuickFix.
  *
  * @author Bera Sogut
  * @see CodeActionHandler
@@ -80,12 +80,14 @@ public class RemoveParamsProposal extends ChangeCorrectionProposal {
         AST ast = declNode.getAST();
         ASTRewrite rewrite = ASTRewrite.create(ast);
 
-        ListRewrite parametersList = rewrite.getListRewrite(declNode, MethodDeclaration.PARAMETERS_PROPERTY);
+        if (declNode instanceof MethodDeclaration) {
+            ListRewrite parametersList = rewrite.getListRewrite(declNode, MethodDeclaration.PARAMETERS_PROPERTY);
 
-        // remove the parameters except the parameter to keep
-        for (SingleVariableDeclaration param : params) {
-            if (!param.equals(paramToKeep)) {
-                parametersList.remove(param, null);
+            // remove the parameters except the parameter to keep
+            for (SingleVariableDeclaration param : params) {
+                if (!param.equals(paramToKeep)) {
+                    parametersList.remove(param, null);
+                }
             }
         }
 

--- a/jakarta-eclipse/org.eclipse.lsp4jakarta.core/src/org/jakarta/jdt/jax_rs/NonPublicResourceMethodQuickFix.java
+++ b/jakarta-eclipse/org.eclipse.lsp4jakarta.core/src/org/jakarta/jdt/jax_rs/NonPublicResourceMethodQuickFix.java
@@ -30,12 +30,13 @@ import org.jakarta.codeAction.proposal.ChangeCorrectionProposal;
 import org.jakarta.codeAction.proposal.ModifyModifiersProposal;
 
 /**
- * Quick fix for ResourceMethodDiagnosticsCollector that uses ChangeVisibilityProposal.
+ * Quick fix for ResourceMethodDiagnosticsCollector that uses
+ * ModifyModifiersProposal.
  * 
  * @author Matthew Shocrylas
  *
  */
-public class ResourceMethodQuickFix implements IJavaCodeActionParticipant {
+public class NonPublicResourceMethodQuickFix implements IJavaCodeActionParticipant {
 
     @Override
     public List<? extends CodeAction> getCodeActions(JavaCodeActionContext context, Diagnostic diagnostic,
@@ -46,12 +47,12 @@ public class ResourceMethodQuickFix implements IJavaCodeActionParticipant {
 
         if (parentMethod != null) {
             List<CodeAction> codeActions = new ArrayList<>();
-            
+
             final String TITLE_MESSAGE = "Make method public";
-            
-            ChangeCorrectionProposal proposal = new ModifyModifiersProposal(TITLE_MESSAGE,
-                    context.getCompilationUnit(), context.getASTRoot(), parentMethod, 0, null, Arrays.asList("public"));
-            
+
+            ChangeCorrectionProposal proposal = new ModifyModifiersProposal(TITLE_MESSAGE, context.getCompilationUnit(),
+                    context.getASTRoot(), parentMethod, 0, null, Arrays.asList("public"));
+
             // Convert the proposal to LSP4J CodeAction
             CodeAction codeAction = context.convertToCodeAction(proposal, diagnostic);
             codeAction.setTitle(TITLE_MESSAGE);

--- a/jakarta-eclipse/org.eclipse.lsp4jakarta.core/src/org/jakarta/jdt/jax_rs/ResourceMethodMultipleEntityParamsQuickFix.java
+++ b/jakarta-eclipse/org.eclipse.lsp4jakarta.core/src/org/jakarta/jdt/jax_rs/ResourceMethodMultipleEntityParamsQuickFix.java
@@ -1,0 +1,105 @@
+/*******************************************************************************
+ * Copyright (c) 2021 IBM Corporation, Bera Sogut and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation, Bera Sogut - initial API and implementation
+ *******************************************************************************/
+
+package org.jakarta.jdt.jax_rs;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.jdt.core.dom.ASTNode;
+import org.eclipse.jdt.core.dom.Annotation;
+import org.eclipse.jdt.core.dom.IExtendedModifier;
+import org.eclipse.jdt.core.dom.IMethodBinding;
+import org.eclipse.jdt.core.dom.MethodDeclaration;
+import org.eclipse.jdt.core.dom.Name;
+import org.eclipse.jdt.core.dom.SingleVariableDeclaration;
+import org.eclipse.lsp4j.CodeAction;
+import org.eclipse.lsp4j.Diagnostic;
+import org.jakarta.codeAction.IJavaCodeActionParticipant;
+import org.jakarta.codeAction.JavaCodeActionContext;
+import org.jakarta.codeAction.proposal.ChangeCorrectionProposal;
+import org.jakarta.codeAction.proposal.RemoveEntityParamsProposal;
+
+/**
+ * Quick fix for the ResourceMethodMultipleEntityParams diagnostic in
+ * ResourceMethodDiagnosticsCollector.
+ *
+ * @author Bera Sogut
+ *
+ */
+public class ResourceMethodMultipleEntityParamsQuickFix implements IJavaCodeActionParticipant {
+
+    @Override
+    public List<? extends CodeAction> getCodeActions(JavaCodeActionContext context, Diagnostic diagnostic,
+            IProgressMonitor monitor) throws CoreException {
+        ASTNode node = context.getCoveredNode();
+        MethodDeclaration parentNode = (MethodDeclaration) node.getParent();
+        IMethodBinding parentMethod = parentNode.resolveBinding();
+
+        if (parentMethod != null) {
+            List<CodeAction> codeActions = new ArrayList<>();
+
+            List<SingleVariableDeclaration> params = (List<SingleVariableDeclaration>) parentNode.parameters();
+
+            List<SingleVariableDeclaration> entityParams = new ArrayList<>();
+
+            for (SingleVariableDeclaration param : params) {
+                if (isEntityParam(param)) {
+                    entityParams.add(param);
+                }
+            }
+
+            for (SingleVariableDeclaration entityParam : entityParams) {
+                final String TITLE_MESSAGE = "Remove all entity parameters except "
+                        + entityParam.getName().getIdentifier();
+
+                ChangeCorrectionProposal proposal = new RemoveEntityParamsProposal(TITLE_MESSAGE,
+                        context.getCompilationUnit(), context.getASTRoot(), parentMethod, 0, entityParams, entityParam);
+
+                // Convert the proposal to LSP4J CodeAction
+                CodeAction codeAction = context.convertToCodeAction(proposal, diagnostic);
+                codeAction.setTitle(TITLE_MESSAGE);
+                codeActions.add(codeAction);
+            }
+
+            return codeActions;
+        }
+        return null;
+    }
+
+    /**
+     * Returns a boolean variable that indicates whether the given parameter is an
+     * entity parameter or not.
+     *
+     * @param param the parameter to check whether it is an entity parameter or not
+     * @return true if the given parameter is an entity parameter, false otherwise
+     */
+    private boolean isEntityParam(SingleVariableDeclaration param) {
+        ArrayList<String> nonEntityParamAnnotations = Jax_RSConstants.NON_ENTITY_PARAM_ANNOTATIONS;
+
+        boolean isEntityParam = true;
+        for (IExtendedModifier modifier : (List<IExtendedModifier>) param.modifiers()) {
+            if (modifier.isAnnotation()) {
+                Name typeName = ((Annotation) modifier).getTypeName();
+                if (nonEntityParamAnnotations.contains(typeName.toString())) {
+                    isEntityParam = false;
+                    break;
+                }
+            }
+        }
+
+        return isEntityParam;
+    }
+}

--- a/jakarta-eclipse/org.eclipse.lsp4jakarta.core/src/org/jakarta/jdt/jax_rs/ResourceMethodMultipleEntityParamsQuickFix.java
+++ b/jakarta-eclipse/org.eclipse.lsp4jakarta.core/src/org/jakarta/jdt/jax_rs/ResourceMethodMultipleEntityParamsQuickFix.java
@@ -30,11 +30,12 @@ import org.eclipse.lsp4j.Diagnostic;
 import org.jakarta.codeAction.IJavaCodeActionParticipant;
 import org.jakarta.codeAction.JavaCodeActionContext;
 import org.jakarta.codeAction.proposal.ChangeCorrectionProposal;
-import org.jakarta.codeAction.proposal.RemoveEntityParamsProposal;
+import org.jakarta.codeAction.proposal.RemoveParamsProposal;
 
 /**
  * Quick fix for the ResourceMethodMultipleEntityParams diagnostic in
- * ResourceMethodDiagnosticsCollector.
+ * ResourceMethodDiagnosticsCollector. This class adds a quick fix for each
+ * entity parameter which removes all entity parameters except the chosen one.
  *
  * @author Bera Sogut
  *
@@ -65,7 +66,8 @@ public class ResourceMethodMultipleEntityParamsQuickFix implements IJavaCodeActi
                 final String TITLE_MESSAGE = "Remove all entity parameters except "
                         + entityParam.getName().getIdentifier();
 
-                ChangeCorrectionProposal proposal = new RemoveEntityParamsProposal(TITLE_MESSAGE,
+                // Remove all entity parameters except the current chosen one
+                ChangeCorrectionProposal proposal = new RemoveParamsProposal(TITLE_MESSAGE,
                         context.getCompilationUnit(), context.getASTRoot(), parentMethod, 0, entityParams, entityParam);
 
                 // Convert the proposal to LSP4J CodeAction

--- a/jakarta-eclipse/org.eclipse.lsp4jakarta.tests/src/main/java/org/eclipse/lsp4jakarta/jdt/jax_rs/ResourceMethodTest.java
+++ b/jakarta-eclipse/org.eclipse.lsp4jakarta.tests/src/main/java/org/eclipse/lsp4jakarta/jdt/jax_rs/ResourceMethodTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 IBM Corporation, Matthew Shocrylas and others.
+ * Copyright (c) 2021 IBM Corporation, Matthew Shocrylas, Bera Sogut and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -74,6 +74,18 @@ public class ResourceMethodTest extends BaseJakartaTest {
                 DiagnosticSeverity.Error, "jakarta-jax_rs", "ResourceMethodMultipleEntityParams");
 
         assertJavaDiagnostics(diagnosticsParams, utils, d);
+
+
+        // Test for quick-fix code action
+        JakartaJavaCodeActionParams codeActionParams = createCodeActionParams(uri, d);
+
+        TextEdit te1 = te(21, 112, 21, 130, "");
+        CodeAction ca1 = ca(uri, "Remove all entity parameters except entityParam1", d, te1);
+
+        TextEdit te2 = te(21, 47, 21, 68, "");
+        CodeAction ca2 = ca(uri, "Remove all entity parameters except entityParam2", d, te2);
+
+        assertJavaCodeAction(codeActionParams, utils, ca1, ca2);
     }
 
 }


### PR DESCRIPTION
Closes #132 

If there exists more than one entity parameter in a resource method, add quick fixes for each of the entity parameters which removes all entity parameters except that one.

For diagnostic #131 