### PR TITLE
Fixed keystroke delay (#26)

### DIFF
--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/core/JDTUtils.java
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/core/JDTUtils.java
@@ -85,6 +85,8 @@ public class JDTUtils {
     private static Set<String> SILENCED_CODEGENS = Collections.singleton("lombok");
 
     public static final String DEFAULT_PROJECT_NAME = "jdt.java-project";
+    
+    private static final int COMPILATION_UNIT_UPDATE_TIMEOUT = 3000;
 
     /**
      * Given the uri returns a {@link ICompilationUnit}. May return null if it can
@@ -119,8 +121,9 @@ public class JDTUtils {
                 if (org.eclipse.jdt.internal.core.util.Util.isJavaLikeFileName(name)) {
                     ICompilationUnit unit = JavaCore.createCompilationUnitFrom(resource);
                     try {
-                        // Give underlying resource time to catch up (max 3 seconds).
-                        long endTime = System.currentTimeMillis() + 3000;
+                        // Give underlying resource time to catch up
+                        // (timeout at COMPILATION_UNIT_UPDATE_TIMEOUT milliseconds).
+                        long endTime = System.currentTimeMillis() + COMPILATION_UNIT_UPDATE_TIMEOUT;
                         while (!unit.isConsistent() && System.currentTimeMillis() < endTime) { }
                     } catch (JavaModelException e) { }
                     return unit;

--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/core/JDTUtils.java
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/core/JDTUtils.java
@@ -117,7 +117,13 @@ public class JDTUtils {
             if (resource.getFileExtension() != null) {
                 String name = resource.getName();
                 if (org.eclipse.jdt.internal.core.util.Util.isJavaLikeFileName(name)) {
-                    return JavaCore.createCompilationUnitFrom(resource);
+                    ICompilationUnit unit = JavaCore.createCompilationUnitFrom(resource);
+                    try {
+                        // Give underlying resource time to catch up (max 3 seconds).
+                        long endTime = System.currentTimeMillis() + 3000;
+                        while (!unit.isConsistent() && System.currentTimeMillis() < endTime) { }
+                    } catch (JavaModelException e) { }
+                    return unit;
                 }
             }
             return null;


### PR DESCRIPTION
See my [comment](https://github.com/eclipse/lsp4jakarta/issues/26#issuecomment-954398977) in issue #26.

I decided to put the loop in `JDTUtils.resolveCompilationUnit()` so that anything that uses it has a consistent `ICompilationUnit`. I set the while loop timeout to 3 seconds, just in case.