### PR TITLE
DI: diagnostic and quick fix for final/abstract injectable methods

### DIFF
--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/codeAction/CodeActionHandler.java
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/codeAction/CodeActionHandler.java
@@ -47,6 +47,7 @@ import org.eclipse.lsp4jakarta.jdt.core.cdi.ManagedBeanConstructorQuickFix;
 import org.eclipse.lsp4jakarta.jdt.core.cdi.ManagedBeanQuickFix;
 import org.eclipse.lsp4jakarta.jdt.core.cdi.ScopeDeclarationQuickFix;
 import org.eclipse.lsp4jakarta.jdt.core.di.DependencyInjectionConstants;
+import org.eclipse.lsp4jakarta.jdt.core.di.RemoveAbstractModifierQuickFix;
 import org.eclipse.lsp4jakarta.jdt.core.di.RemoveFinalModifierQuickFix;
 import org.eclipse.lsp4jakarta.jdt.core.di.RemoveInjectAnnotationQuickFix;
 import org.eclipse.lsp4jakarta.jdt.core.servlet.CompleteFilterAnnotationQuickFix;
@@ -104,7 +105,7 @@ public class CodeActionHandler {
             ScopeDeclarationQuickFix ScopeDeclarationQuickFix = new ScopeDeclarationQuickFix();
             RemoveInjectAnnotationQuickFix RemoveInjectAnnotationQuickFix = new RemoveInjectAnnotationQuickFix();
             RemoveFinalModifierQuickFix RemoveFinalModifierQuickFix = new RemoveFinalModifierQuickFix();
-            
+            RemoveAbstractModifierQuickFix RemoveAbstractModifierQuickFix = new RemoveAbstractModifierQuickFix();
             
             for (Diagnostic diagnostic : params.getContext().getDiagnostics()) {
                 try {
@@ -179,6 +180,10 @@ public class CodeActionHandler {
                     }
                     if(diagnostic.getCode().getLeft().equals(DependencyInjectionConstants.DIAGNOSTIC_CODE_INJECT_CONSTRUCTOR)) {
                         codeActions.addAll(RemoveInjectAnnotationQuickFix.getCodeActions(context, diagnostic, monitor));
+                    }
+                    if(diagnostic.getCode().getLeft().equals(DependencyInjectionConstants.DIAGNOSTIC_CODE_INJECT_ABSTRACT)) {
+                        codeActions.addAll(RemoveInjectAnnotationQuickFix.getCodeActions(context, diagnostic, monitor));
+                        codeActions.addAll(RemoveAbstractModifierQuickFix.getCodeActions(context, diagnostic, monitor));
                     }
                 } catch (CoreException e) {
                     e.printStackTrace();

--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/codeAction/CodeActionHandler.java
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/codeAction/CodeActionHandler.java
@@ -50,6 +50,7 @@ import org.eclipse.lsp4jakarta.jdt.core.di.DependencyInjectionConstants;
 import org.eclipse.lsp4jakarta.jdt.core.di.RemoveAbstractModifierQuickFix;
 import org.eclipse.lsp4jakarta.jdt.core.di.RemoveFinalModifierQuickFix;
 import org.eclipse.lsp4jakarta.jdt.core.di.RemoveInjectAnnotationQuickFix;
+import org.eclipse.lsp4jakarta.jdt.core.di.RemoveStaticModifierQuickFix;
 import org.eclipse.lsp4jakarta.jdt.core.servlet.CompleteFilterAnnotationQuickFix;
 import org.eclipse.lsp4jakarta.jdt.core.servlet.CompleteServletAnnotationQuickFix;
 import org.eclipse.lsp4jakarta.jdt.core.servlet.FilterImplementationQuickFix;
@@ -106,6 +107,7 @@ public class CodeActionHandler {
             RemoveInjectAnnotationQuickFix RemoveInjectAnnotationQuickFix = new RemoveInjectAnnotationQuickFix();
             RemoveFinalModifierQuickFix RemoveFinalModifierQuickFix = new RemoveFinalModifierQuickFix();
             RemoveAbstractModifierQuickFix RemoveAbstractModifierQuickFix = new RemoveAbstractModifierQuickFix();
+            RemoveStaticModifierQuickFix RemoveStaticModifierQuickFix = new RemoveStaticModifierQuickFix();
             
             for (Diagnostic diagnostic : params.getContext().getDiagnostics()) {
                 try {
@@ -178,12 +180,17 @@ public class CodeActionHandler {
                         codeActions.addAll(RemoveInjectAnnotationQuickFix.getCodeActions(context, diagnostic, monitor));
                         codeActions.addAll(RemoveFinalModifierQuickFix.getCodeActions(context, diagnostic, monitor));
                     }
-                    if(diagnostic.getCode().getLeft().equals(DependencyInjectionConstants.DIAGNOSTIC_CODE_INJECT_CONSTRUCTOR)) {
+                    if(diagnostic.getCode().getLeft().equals(DependencyInjectionConstants.DIAGNOSTIC_CODE_INJECT_CONSTRUCTOR) ||
+                            diagnostic.getCode().getLeft().equals(DependencyInjectionConstants.DIAGNOSTIC_CODE_INJECT_GENERIC)) {
                         codeActions.addAll(RemoveInjectAnnotationQuickFix.getCodeActions(context, diagnostic, monitor));
                     }
                     if(diagnostic.getCode().getLeft().equals(DependencyInjectionConstants.DIAGNOSTIC_CODE_INJECT_ABSTRACT)) {
                         codeActions.addAll(RemoveInjectAnnotationQuickFix.getCodeActions(context, diagnostic, monitor));
                         codeActions.addAll(RemoveAbstractModifierQuickFix.getCodeActions(context, diagnostic, monitor));
+                    }
+                    if(diagnostic.getCode().getLeft().equals(DependencyInjectionConstants.DIAGNOSTIC_CODE_INJECT_STATIC)) {
+                        codeActions.addAll(RemoveInjectAnnotationQuickFix.getCodeActions(context, diagnostic, monitor));
+                        codeActions.addAll(RemoveStaticModifierQuickFix.getCodeActions(context, diagnostic, monitor));
                     }
                 } catch (CoreException e) {
                     e.printStackTrace();

--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/core/di/DependencyInjectionConstants.java
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/core/di/DependencyInjectionConstants.java
@@ -28,6 +28,7 @@ public class DependencyInjectionConstants {
     public static final String DIAGNOSTIC_SOURCE = "jakarta-di";
     public static final String DIAGNOSTIC_CODE_INJECT_FINAL = "RemoveInjectOrFinal";
     public static final String DIAGNOSTIC_CODE_INJECT_CONSTRUCTOR = "RemoveInject";
-    
+    public static final String DIAGNOSTIC_CODE_INJECT_ABSTRACT = "RemoveInjectOrAbstract";
+
     public static final DiagnosticSeverity SEVERITY = DiagnosticSeverity.Error;
 }

--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/core/di/DependencyInjectionConstants.java
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/core/di/DependencyInjectionConstants.java
@@ -17,18 +17,19 @@ import org.eclipse.lsp4j.DiagnosticSeverity;
 
 public class DependencyInjectionConstants {
 
-	/* Annotation Constants */
+    /* Annotation Constants */
     public static final String PRODUCES = "Produces";
     public static final String INJECT = "Inject";
     public static final String QUALIFIER = "Qualifier";
     public static final String NAMED = "Named";
 
-    
     /* Diagnostics fields constants */
     public static final String DIAGNOSTIC_SOURCE = "jakarta-di";
     public static final String DIAGNOSTIC_CODE_INJECT_FINAL = "RemoveInjectOrFinal";
     public static final String DIAGNOSTIC_CODE_INJECT_CONSTRUCTOR = "RemoveInject";
     public static final String DIAGNOSTIC_CODE_INJECT_ABSTRACT = "RemoveInjectOrAbstract";
+    public static final String DIAGNOSTIC_CODE_INJECT_STATIC = "RemoveInjectOrStatic";
+    public static final String DIAGNOSTIC_CODE_INJECT_GENERIC = "RemoveInject";
 
     public static final DiagnosticSeverity SEVERITY = DiagnosticSeverity.Error;
 }

--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/core/di/DependencyInjectionDiagnosticsCollector.java
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/core/di/DependencyInjectionDiagnosticsCollector.java
@@ -85,6 +85,7 @@ public class DependencyInjectionDiagnosticsCollector implements DiagnosticsColle
     public void collectDiagnostics(ICompilationUnit unit, List<Diagnostic> diagnostics) {
         if (unit == null)
             return;
+
         Diagnostic diagnostic;
         IType[] alltypes;
         IAnnotation[] allAnnotations;
@@ -196,5 +197,4 @@ public class DependencyInjectionDiagnosticsCollector implements DiagnosticsColle
             JakartaCorePlugin.logException("Cannot calculate diagnostics", e);
         }
     }
-
 }

--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/core/di/DependencyInjectionDiagnosticsCollector.java
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/core/di/DependencyInjectionDiagnosticsCollector.java
@@ -50,9 +50,9 @@ import org.eclipse.jdt.core.IMethod;
  * @see https://jakarta.ee/specifications/dependency-injection/2.0/jakarta-injection-spec-2.0.html
  *
  */
-public class DependencyInjectionDiagnosticsCollector implements DiagnosticsCollector{
-	
-	private Diagnostic createDiagnostic(IJavaElement el, ICompilationUnit unit, String msg, String code) {
+public class DependencyInjectionDiagnosticsCollector implements DiagnosticsCollector {
+
+    private Diagnostic createDiagnostic(IJavaElement el, ICompilationUnit unit, String msg, String code) {
         try {
             ISourceRange nameRange = JDTUtils.getNameRange(el);
             Range range = JDTUtils.toRange(unit, nameRange.getOffset(), nameRange.getLength());
@@ -61,132 +61,140 @@ public class DependencyInjectionDiagnosticsCollector implements DiagnosticsColle
             completeDiagnostic(diagnostic);
             return diagnostic;
         } catch (JavaModelException e) {
-        	JakartaCorePlugin.logException("Cannot calculate diagnostics", e);
+            JakartaCorePlugin.logException("Cannot calculate diagnostics", e);
         }
         return null;
     }
-    
 
     @Override
     public void completeDiagnostic(Diagnostic diagnostic) {
         diagnostic.setSource(DIAGNOSTIC_SOURCE);
         diagnostic.setSeverity(SEVERITY);
-	}
-    
- // checks if a method is a constructor
- 	private boolean isConstructorMethod(IMethod m) {
-         try {
-             return m.isConstructor();
-         } catch (JavaModelException e) {
-             return false;
-         }
-     }
+    }
 
-	@Override
-	public void collectDiagnostics(ICompilationUnit unit, List<Diagnostic> diagnostics) {
-	    if (unit == null)
+    // checks if a method is a constructor
+    private boolean isConstructorMethod(IMethod m) {
+        try {
+            return m.isConstructor();
+        } catch (JavaModelException e) {
+            return false;
+        }
+    }
+
+    @Override
+    public void collectDiagnostics(ICompilationUnit unit, List<Diagnostic> diagnostics) {
+        if (unit == null)
             return;
-	    Diagnostic diagnostic;
-	    IType[] alltypes;
-	    IAnnotation[] allAnnotations;
-	    try {
-	        alltypes = unit.getAllTypes();
-	        for (IType type : alltypes) {
-	            allAnnotations = type.getAnnotations();
+        Diagnostic diagnostic;
+        IType[] alltypes;
+        IAnnotation[] allAnnotations;
+        try {
+            alltypes = unit.getAllTypes();
+            for (IType type : alltypes) {
+                allAnnotations = type.getAnnotations();
 
-	            IField[] allFields = type.getFields();
-	            for (IField field : allFields) {
-	                int fieldFlags = field.getFlags();
-	                List<IAnnotation> fieldAnnotations = Arrays.asList(field.getAnnotations());
+                IField[] allFields = type.getFields();
+                for (IField field : allFields) {
+                    int fieldFlags = field.getFlags();
+                    List<IAnnotation> fieldAnnotations = Arrays.asList(field.getAnnotations());
 
-	                boolean isInjectField = fieldAnnotations.stream()
-	                        .anyMatch(annotation -> annotation.getElementName()
-	                                .equals(DependencyInjectionConstants.INJECT));
+                    boolean isInjectField = fieldAnnotations.stream().anyMatch(
+                            annotation -> annotation.getElementName().equals(DependencyInjectionConstants.INJECT));
 
-	                boolean isFinal = Flags.isFinal(fieldFlags);
+                    boolean isFinal = Flags.isFinal(fieldFlags);
 
-	                if (isFinal && isInjectField) {
-	                    ISourceRange nameRange = JDTUtils.getNameRange(field);
-	                    Range range = JDTUtils.toRange(unit, nameRange.getOffset(), nameRange.getLength());
-	                    String msg = "Injectable fields cannot be final";
-	                    diagnostic = new Diagnostic(range, msg);
-	                    diagnostic.setCode(DependencyInjectionConstants.DIAGNOSTIC_CODE_INJECT_FINAL);
-	                    diagnostic.setData(field.getElementType());
-	                    completeDiagnostic(diagnostic);
-	                    diagnostics.add(diagnostic);    
-	                }    
-	            }
-	            
-	            IMethod[] allMethods = type.getMethods();
-	            for (IMethod method: allMethods) {
-	                List<IAnnotation> methodAnnotations = Arrays.asList(method.getAnnotations());
-	                
-	                boolean isInjectMethod = methodAnnotations.stream()
-                            .anyMatch(annotation -> annotation.getElementName()
-                                    .equals(DependencyInjectionConstants.INJECT));
-	                
-	                int methodFlag = method.getFlags();
-	                boolean isFinal = Flags.isFinal(methodFlag);
-	                boolean isAbstract = Flags.isAbstract(methodFlag);
-
-	                if (isFinal && isInjectMethod) {
-	                    ISourceRange nameRange = JDTUtils.getNameRange(method);
-	                    Range range = JDTUtils.toRange(unit, nameRange.getOffset(), nameRange.getLength());
-	                    String msg = "Injectable methods cannot be final";
-	                    diagnostic = new Diagnostic(range, msg);
-	                    diagnostic.setCode(DependencyInjectionConstants.DIAGNOSTIC_CODE_INJECT_FINAL);
-	                    diagnostic.setData(method.getElementType());
-	                    completeDiagnostic(diagnostic);
+                    if (isFinal && isInjectField) {
+                        String msg = "Injectable fields cannot be final";
+                        diagnostic = createDiagnostic(field, unit, msg,
+                                DependencyInjectionConstants.DIAGNOSTIC_CODE_INJECT_FINAL);
+                        diagnostic.setData(field.getElementType());
                         diagnostics.add(diagnostic);
-	                }
-	                
-	                if (isAbstract && isInjectMethod) {
-                        ISourceRange nameRange = JDTUtils.getNameRange(method);
-                        Range range = JDTUtils.toRange(unit, nameRange.getOffset(), nameRange.getLength());
-                        String msg = "Injectable methods cannot be abstract";
-                        diagnostic = new Diagnostic(range, msg);
-                        diagnostic.setCode(DependencyInjectionConstants.DIAGNOSTIC_CODE_INJECT_ABSTRACT);
+                    }
+                }
+
+                IMethod[] allMethods = type.getMethods();
+                for (IMethod method : allMethods) {
+                    List<IAnnotation> methodAnnotations = Arrays.asList(method.getAnnotations());
+
+                    boolean isInjectMethod = methodAnnotations.stream().anyMatch(
+                            annotation -> annotation.getElementName().equals(DependencyInjectionConstants.INJECT));
+
+                    int methodFlag = method.getFlags();
+                    boolean isFinal = Flags.isFinal(methodFlag);
+                    boolean isAbstract = Flags.isAbstract(methodFlag);
+                    boolean isStatic = Flags.isStatic(methodFlag);
+                    boolean isGeneric = method.getTypeParameters().length != 0;
+
+                    if (isFinal && isInjectMethod) {
+                        String msg = "Injectable methods cannot be final";
+                        diagnostic = createDiagnostic(method, unit, msg,
+                                DependencyInjectionConstants.DIAGNOSTIC_CODE_INJECT_FINAL);
                         diagnostic.setData(method.getElementType());
-                        completeDiagnostic(diagnostic);
                         diagnostics.add(diagnostic);
                     }
 
-	            }
-	        }
-	        for (IType type : alltypes) {
-                List<IMethod> constructorMethods = Arrays.stream(type.getMethods())
-	                    .filter(this::isConstructorMethod).collect(Collectors.toList());
-				
-				//there are no constructors
-				if(constructorMethods.size() == 0)
-					return;
-				boolean hasInjectConstructor = false;
-				boolean multipleInjectConstructor = false;
-				int numInjectedConstructors = 0;
-				List<IMethod> injectedConstructors = new ArrayList<IMethod>();
-				for (IMethod m : constructorMethods) {
-					hasInjectConstructor = Arrays.stream(m.getAnnotations())
-                    .map(annotation -> annotation.getElementName())
-                    .anyMatch(annotation -> annotation.equals("Inject"));
-					if (hasInjectConstructor) {
-						injectedConstructors.add(m);
-						numInjectedConstructors++;
-						if(numInjectedConstructors > 1) {
-							 multipleInjectConstructor = true; //if more than one constructor, add diagnostic to all constructors
-						}
-					}
-				}
-				
-				if(multipleInjectConstructor) {
-					for (IMethod m : injectedConstructors) {
-						diagnostics.add(createDiagnostic(m,unit,"Inject cannot be used with multiple constructors",DIAGNOSTIC_CODE_INJECT_CONSTRUCTOR));
-					}
-				}
-			}
-	    }catch (JavaModelException e) {
-	        JakartaCorePlugin.logException("Cannot calculate diagnostics", e);    
-	    }    
-	}
+                    if (isAbstract && isInjectMethod) {
+                        String msg = "Injectable methods cannot be abstract";
+                        diagnostic = createDiagnostic(method, unit, msg,
+                                DependencyInjectionConstants.DIAGNOSTIC_CODE_INJECT_ABSTRACT);
+                        diagnostic.setData(method.getElementType());
+                        diagnostics.add(diagnostic);
+                    }
+
+                    if (isStatic && isInjectMethod) {
+                        String msg = "Injectable methods cannot be static";
+                        diagnostic = createDiagnostic(method, unit, msg,
+                                DependencyInjectionConstants.DIAGNOSTIC_CODE_INJECT_STATIC);
+                        diagnostic.setData(method.getElementType());
+                        diagnostics.add(diagnostic);
+                    }
+
+                    if (isGeneric && isInjectMethod) {
+                        String msg = "Injectable methods cannot be generic";
+                        diagnostic = createDiagnostic(method, unit, msg,
+                                DependencyInjectionConstants.DIAGNOSTIC_CODE_INJECT_GENERIC);
+                        diagnostic.setData(method.getElementType());
+                        diagnostics.add(diagnostic);
+                    }
+
+                }
+            }
+
+            for (IType type : alltypes) {
+                List<IMethod> constructorMethods = Arrays.stream(type.getMethods()).filter(this::isConstructorMethod)
+                        .collect(Collectors.toList());
+
+                // there are no constructors
+                if (constructorMethods.size() == 0)
+                    return;
+                boolean hasInjectConstructor = false;
+                boolean multipleInjectConstructor = false;
+                int numInjectedConstructors = 0;
+                List<IMethod> injectedConstructors = new ArrayList<IMethod>();
+                for (IMethod m : constructorMethods) {
+                    hasInjectConstructor = Arrays.stream(m.getAnnotations())
+                            .map(annotation -> annotation.getElementName())
+                            .anyMatch(annotation -> annotation.equals("Inject"));
+                    if (hasInjectConstructor) {
+                        injectedConstructors.add(m);
+                        numInjectedConstructors++;
+                        if (numInjectedConstructors > 1) {
+                            multipleInjectConstructor = true; // if more than one constructor, add diagnostic to all
+                                                              // constructors
+                        }
+                    }
+                }
+
+                if (multipleInjectConstructor) {
+                    for (IMethod m : injectedConstructors) {
+                        diagnostics.add(createDiagnostic(m, unit, "Inject cannot be used with multiple constructors",
+                                DIAGNOSTIC_CODE_INJECT_CONSTRUCTOR));
+                    }
+                }
+            }
+        } catch (JavaModelException e) {
+            JakartaCorePlugin.logException("Cannot calculate diagnostics", e);
+        }
+    }
 
 }
-

--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/core/di/RemoveAbstractModifierQuickFix.java
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/core/di/RemoveAbstractModifierQuickFix.java
@@ -1,0 +1,28 @@
+/*******************************************************************************
+* Copyright (c) 2021 IBM Corporation and others.
+*
+* This program and the accompanying materials are made available under the
+* terms of the Eclipse Public License v. 2.0 which is available at
+* http://www.eclipse.org/legal/epl-2.0
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*     IBM Corporation, Himanshu Chotwani - initial API and implementation
+*******************************************************************************/
+package org.eclipse.lsp4jakarta.jdt.core.di;
+
+import org.eclipse.lsp4jakarta.jdt.codeAction.proposal.quickfix.RemoveModifierConflictQuickFix;
+
+/**
+ * 
+ * Quick fix for removing abstract when it is used for method with @Inject
+ * 
+ * @author Himanshu Chotwani
+ *
+ */
+public class RemoveAbstractModifierQuickFix extends RemoveModifierConflictQuickFix{
+    public RemoveAbstractModifierQuickFix() {
+        super (false, "abstract");
+    }
+}

--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/core/di/RemoveStaticModifierQuickFix.java
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/core/di/RemoveStaticModifierQuickFix.java
@@ -1,0 +1,31 @@
+/*******************************************************************************
+* Copyright (c) 2021 IBM Corporation and others.
+*
+* This program and the accompanying materials are made available under the
+* terms of the Eclipse Public License v. 2.0 which is available at
+* http://www.eclipse.org/legal/epl-2.0
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*     IBM Corporation, Himanshu Chotwani - initial API and implementation
+*******************************************************************************/
+
+package org.eclipse.lsp4jakarta.jdt.core.di;
+
+import org.eclipse.lsp4jakarta.jdt.codeAction.proposal.quickfix.RemoveModifierConflictQuickFix;
+
+
+/**
+ * 
+ * Quick fix for removing static modifier when it is used for a method with @Inject
+ * 
+ * @author Himanshu Chotwani
+ *
+ */
+public class RemoveStaticModifierQuickFix extends RemoveModifierConflictQuickFix {
+    
+    public RemoveStaticModifierQuickFix() {
+        super(false, "static");
+    }
+}


### PR DESCRIPTION
Should close #168
Diagnostic for abstract/final/static/generic method(s) with `@Inject`
Quick fix to either remove `@Inject` annotation or the modifier(s)
Integration tests to be added in a later patch