### PR TITLE
Added quickfix to create no-arg constructor for managed beans

### DIFF
--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/codeAction/CodeActionHandler.java
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/codeAction/CodeActionHandler.java
@@ -48,6 +48,7 @@ import org.eclipse.lsp4jakarta.jdt.core.jsonb.JsonbConstants;
 import org.eclipse.lsp4jakarta.jdt.core.cdi.ConflictProducesInjectQuickFix;
 import org.eclipse.lsp4jakarta.jdt.core.cdi.ManagedBeanConstants;
 import org.eclipse.lsp4jakarta.jdt.core.cdi.ManagedBeanConstructorQuickFix;
+import org.eclipse.lsp4jakarta.jdt.core.cdi.ManagedBeanNoArgConstructorQuickFix;
 import org.eclipse.lsp4jakarta.jdt.core.cdi.ManagedBeanQuickFix;
 import org.eclipse.lsp4jakarta.jdt.core.cdi.ScopeDeclarationQuickFix;
 import org.eclipse.lsp4jakarta.jdt.core.di.DependencyInjectionConstants;
@@ -102,6 +103,7 @@ public class CodeActionHandler {
             ConflictProducesInjectQuickFix ConflictProducesInjectQuickFix = new ConflictProducesInjectQuickFix();
             BeanValidationQuickFix BeanValidationQuickFix = new BeanValidationQuickFix();
             ManagedBeanConstructorQuickFix ManagedBeanConstructorQuickFix = new ManagedBeanConstructorQuickFix();
+            ManagedBeanNoArgConstructorQuickFix ManagedBeanNoArgConstructorQuickFix = new ManagedBeanNoArgConstructorQuickFix();
             JsonbAnnotationQuickFix JsonbAnnotationQuickFix = new JsonbAnnotationQuickFix();
             ScopeDeclarationQuickFix ScopeDeclarationQuickFix = new ScopeDeclarationQuickFix();
             RemoveInjectAnnotationQuickFix RemoveInjectAnnotationQuickFix = new RemoveInjectAnnotationQuickFix();
@@ -162,6 +164,9 @@ public class CodeActionHandler {
                     if (diagnostic.getCode().getLeft().equals(ManagedBeanConstants.DIAGNOSTIC_CODE_PRODUCES_INJECT)) {
                         codeActions.addAll(ConflictProducesInjectQuickFix.getCodeActions(context, diagnostic, monitor));
                     }
+                    if (diagnostic.getCode().getLeft().equals(ManagedBeanConstants.DIAGNOSTIC_CODE_INVALID_INJECT_PARAM)) {
+                        codeActions.addAll(RemoveInjectAnnotationQuickFix.getCodeActions(context, diagnostic, monitor));
+                    }
                     if (diagnostic.getCode().getLeft().equals(BeanValidationConstants.DIAGNOSTIC_CODE_STATIC)
                             || diagnostic.getCode().getLeft()
                                     .equals(BeanValidationConstants.DIAGNOSTIC_CODE_INVALID_TYPE)) {
@@ -169,6 +174,7 @@ public class CodeActionHandler {
                     }
                     if (diagnostic.getCode().getLeft().equals(ManagedBeanConstants.CONSTRUCTOR_DIAGNOSTIC_CODE)) {
                         codeActions.addAll(ManagedBeanConstructorQuickFix.getCodeActions(context, diagnostic, monitor));
+                        codeActions.addAll(ManagedBeanNoArgConstructorQuickFix.getCodeActions(context, diagnostic, monitor));
                     }
                     if (diagnostic.getCode().getLeft().equals(JsonbConstants.DIAGNOSTIC_CODE_ANNOTATION)) {
                         codeActions.addAll(JsonbAnnotationQuickFix.getCodeActions(context, diagnostic, monitor));

--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/core/cdi/ManagedBeanDiagnosticsCollector.java
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/core/cdi/ManagedBeanDiagnosticsCollector.java
@@ -244,7 +244,7 @@ public class ManagedBeanDiagnosticsCollector implements DiagnosticsCollector {
 
                         for (IMethod m : methodsNeedingDiagnostics) {
                             Diagnostic diagnostic = createDiagnostic(m, unit,
-                                    "If a managed bean does not have a constructor that takes no parameters, it must have a constructor annotated @Inject",
+                                    "If a managed bean has a constructor that takes parameters, it must have be annotated @Inject or have a no-arg constructor defined",
                                     CONSTRUCTOR_DIAGNOSTIC_CODE);
                             diagnostics.add(diagnostic);
                         }

--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/core/cdi/ManagedBeanNoArgConstructorQuickFix.java
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/core/cdi/ManagedBeanNoArgConstructorQuickFix.java
@@ -1,0 +1,84 @@
+/*******************************************************************************
+* Copyright (c) 2021 IBM Corporation.
+*
+* This program and the accompanying materials are made available under the
+* terms of the Eclipse Public License v. 2.0 which is available at
+* http://www.eclipse.org/legal/epl-2.0.
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*     Hani Damlaj
+*******************************************************************************/
+
+package org.eclipse.lsp4jakarta.jdt.core.cdi;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.jdt.core.dom.ASTNode;
+import org.eclipse.jdt.core.dom.IBinding;
+import org.eclipse.jdt.core.dom.VariableDeclarationFragment;
+import org.eclipse.jdt.internal.corext.dom.Bindings;
+import org.eclipse.lsp4j.CodeAction;
+import org.eclipse.lsp4j.Diagnostic;
+import org.eclipse.lsp4jakarta.jdt.codeAction.IJavaCodeActionParticipant;
+import org.eclipse.lsp4jakarta.jdt.codeAction.JavaCodeActionContext;
+import org.eclipse.lsp4jakarta.jdt.codeAction.proposal.AddConstructorProposal;
+import org.eclipse.lsp4jakarta.jdt.codeAction.proposal.ChangeCorrectionProposal;
+import org.eclipse.lsp4jakarta.jdt.core.persistence.PersistenceConstants;
+
+public class ManagedBeanNoArgConstructorQuickFix  implements IJavaCodeActionParticipant   {
+
+    @Override
+    public List<? extends CodeAction> getCodeActions(JavaCodeActionContext context, Diagnostic diagnostic,
+            IProgressMonitor monitor) throws CoreException {
+        ASTNode node = context.getCoveredNode();
+        IBinding parentType = getBinding(node);
+        if (parentType != null) {
+            List<CodeAction> codeActions = new ArrayList<>();
+            
+            codeActions.addAll(addConstructor(diagnostic, context, parentType));
+           
+
+            return codeActions;
+        }
+        return null;
+    }
+    
+    protected static IBinding getBinding(ASTNode node) {
+        if (node.getParent() instanceof VariableDeclarationFragment) {
+            VariableDeclarationFragment fragment = (VariableDeclarationFragment) node.getParent();
+            return ((VariableDeclarationFragment) node.getParent()).resolveBinding();
+        }
+        return Bindings.getBindingOfParentType(node);
+    }
+    
+    private List<CodeAction> addConstructor(Diagnostic diagnostic, JavaCodeActionContext context, IBinding parentType) throws CoreException {
+        List<CodeAction> codeActions = new ArrayList<>();
+
+        // option for protected constructor
+        String name = "Add a no-arg protected constructor to this class";
+        ChangeCorrectionProposal proposal = new AddConstructorProposal(name,
+                context.getCompilationUnit(), context.getASTRoot(), parentType, 0);
+        CodeAction codeAction = context.convertToCodeAction(proposal, diagnostic);
+
+        if (codeAction != null) {
+            codeActions.add(codeAction);
+        }
+
+        // option for public constructor
+        name = "Add a no-arg public constructor to this class";
+        proposal = new AddConstructorProposal(name,
+                context.getCompilationUnit(), context.getASTRoot(), parentType, 0, "public");
+        codeAction = context.convertToCodeAction(proposal, diagnostic);
+
+        if (codeAction != null) {
+            codeActions.add(codeAction);
+        }
+
+        return codeActions;
+    }
+}

--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/core/cdi/ManagedBeanNoArgConstructorQuickFix.java
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/core/cdi/ManagedBeanNoArgConstructorQuickFix.java
@@ -14,6 +14,7 @@
 package org.eclipse.lsp4jakarta.jdt.core.cdi;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 
 import org.eclipse.core.runtime.CoreException;
@@ -28,7 +29,15 @@ import org.eclipse.lsp4jakarta.jdt.codeAction.IJavaCodeActionParticipant;
 import org.eclipse.lsp4jakarta.jdt.codeAction.JavaCodeActionContext;
 import org.eclipse.lsp4jakarta.jdt.codeAction.proposal.AddConstructorProposal;
 import org.eclipse.lsp4jakarta.jdt.codeAction.proposal.ChangeCorrectionProposal;
-import org.eclipse.lsp4jakarta.jdt.core.persistence.PersistenceConstants;
+
+/**
+ * 
+ * Quick fix for adding a `protected`/`public` no argument constructor 
+ * for a managed bean that do not have:
+ * - a no argument constructor
+ * - a constructor annotated with `@Inject`
+ *
+ */
 
 public class ManagedBeanNoArgConstructorQuickFix  implements IJavaCodeActionParticipant   {
 

--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.test/src/main/java/org/eclipse/lsp4jakarta/jdt/cdi/ManagedBeanConstructorTest.java
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.test/src/main/java/org/eclipse/lsp4jakarta/jdt/cdi/ManagedBeanConstructorTest.java
@@ -46,17 +46,23 @@ public class ManagedBeanConstructorTest extends BaseJakartaTest {
 
         // test expected diagnostic
         Diagnostic d = d(21, 8, 30,
-                "If a managed bean does not have a constructor that takes no parameters, it must have a constructor annotated @Inject",
+                "If a managed bean has a constructor that takes parameters, it must have be annotated @Inject or have a no-arg constructor defined",
                 DiagnosticSeverity.Error, "jakarta-cdi", "InvalidManagedBeanConstructor");
 
         assertJavaDiagnostics(diagnosticsParams, JDT_UTILS, d);
 
         // test expected quick-fix
-        JakartaJavaCodeActionParams codeActionParams = createCodeActionParams(uri, d);
-        TextEdit te = te(15, 44, 21, 1,
+        JakartaJavaCodeActionParams codeActionParams1 = createCodeActionParams(uri, d);
+        TextEdit te1 = te(15, 44, 21, 1,
                 "\nimport jakarta.inject.Inject;\n\n@Dependent\npublic class ManagedBeanConstructor {\n	private int a;\n	\n	@Inject\n	");
-        CodeAction ca = ca(uri, "Insert @Inject", d, te);
-        assertJavaCodeAction(codeActionParams, JDT_UTILS, ca);
+        TextEdit te2 = te(19, 1, 19, 1,
+        		"protected ManagedBeanConstructor() {\n\t}\n\n\t");
+        TextEdit te3 = te(19, 1, 19, 1,
+                "public ManagedBeanConstructor() {\n\t}\n\n\t");
+        CodeAction ca1 = ca(uri, "Insert @Inject", d, te1);
+        CodeAction ca2 = ca(uri, "Add a no-arg protected constructor to this class", d, te2);
+        CodeAction ca3 = ca(uri, "Add a no-arg public constructor to this class", d, te3);
+        assertJavaCodeAction(codeActionParams1, JDT_UTILS, ca1, ca2, ca3);
     }
 
 }


### PR DESCRIPTION
Provide one quickfix for #191
> Suggest adding snippet code to declare no-arg constructor