### PR TITLE
Add diagnostic support for ServerEndpoint URI validation

### DIFF
--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/core/JDTUtils.java
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/core/JDTUtils.java
@@ -625,4 +625,21 @@ public class JDTUtils {
     public static boolean hasLeadingSlash(String uriString) {
         return uriString.startsWith("/");
     }
+
+    /**
+     * Check if a URI follows a valid URI-template (level-1) specified by
+     * <a href="https://datatracker.ietf.org/doc/html/rfc6570">RFC 6570</a>.
+     *
+     * @param uriString
+     * @return boolean
+     */
+    public static boolean isValidLevel1URI(String uriString, boolean isPartial) {
+        // Regex is obtained from RFC 3986:
+        // https://www.rfc-editor.org/rfc/rfc3986#appendix-B
+        if (isPartial) {
+            return uriString.matches("[^?#]*");
+        } else {
+            return uriString.matches("^(([^:/?#]+):)?(//([^/?#]*))?([^?#]*)(\\?([^#]*))?(#(.*))?");
+        }
+    }
 }

--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/core/JDTUtils.java
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/core/JDTUtils.java
@@ -87,7 +87,7 @@ public class JDTUtils {
     public static final String DEFAULT_PROJECT_NAME = "jdt.java-project";
 
     private static final int COMPILATION_UNIT_UPDATE_TIMEOUT = 3000;
-    private static final String LEVEL1_URI_REGEX = "(?:\\/(?:(?:\\{\\w+\\})|(?:\\w+)))*\\/?";
+    private static final String LEVEL1_URI_REGEX = "(?:\\/(?:(?:\\{(\\w|%20|%21|%23|%24|%25|%26|%27|%28|%29|%2A|%2B|%2C|%2F|%3A|%3B|%3D|%3F|%40|%5B|%5D)+\\})|(?:(\\w|%20|%21|%23|%24|%25|%26|%27|%28|%29|%2A|%2B|%2C|%2F|%3A|%3B|%3D|%3F|%40|%5B|%5D)+)))*\\/?";
 
     /**
      * Given the uri returns a {@link ICompilationUnit}. May return null if it can

--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/core/JDTUtils.java
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/core/JDTUtils.java
@@ -85,8 +85,9 @@ public class JDTUtils {
     private static Set<String> SILENCED_CODEGENS = Collections.singleton("lombok");
 
     public static final String DEFAULT_PROJECT_NAME = "jdt.java-project";
-    
+
     private static final int COMPILATION_UNIT_UPDATE_TIMEOUT = 3000;
+    private static final String LEVEL1_URI_REGEX = "(?:\\/(?:(?:\\{\\w+\\})|(?:\\w+)))*\\/?";
 
     /**
      * Given the uri returns a {@link ICompilationUnit}. May return null if it can
@@ -633,13 +634,7 @@ public class JDTUtils {
      * @param uriString
      * @return boolean
      */
-    public static boolean isValidLevel1URI(String uriString, boolean isPartial) {
-        // Regex is obtained from RFC 3986:
-        // https://www.rfc-editor.org/rfc/rfc3986#appendix-B
-        if (isPartial) {
-            return uriString.matches("[^?#]*");
-        } else {
-            return uriString.matches("^(([^:/?#]+):)?(//([^/?#]*))?([^?#]*)(\\?([^#]*))?(#(.*))?");
-        }
+    public static boolean isValidLevel1URI(String uriString) {
+        return uriString.matches(LEVEL1_URI_REGEX);
     }
 }

--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/core/JDTUtils.java
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/core/JDTUtils.java
@@ -87,7 +87,7 @@ public class JDTUtils {
     public static final String DEFAULT_PROJECT_NAME = "jdt.java-project";
 
     private static final int COMPILATION_UNIT_UPDATE_TIMEOUT = 3000;
-    private static final String LEVEL1_URI_REGEX = "(?:\\/(?:(?:\\{(\\w|%20|%21|%23|%24|%25|%26|%27|%28|%29|%2A|%2B|%2C|%2F|%3A|%3B|%3D|%3F|%40|%5B|%5D)+\\})|(?:(\\w|%20|%21|%23|%24|%25|%26|%27|%28|%29|%2A|%2B|%2C|%2F|%3A|%3B|%3D|%3F|%40|%5B|%5D)+)))*\\/?";
+    private static final String LEVEL1_URI_REGEX = "(?:\\/(?:(?:\\{(\\w|-|%20|%21|%23|%24|%25|%26|%27|%28|%29|%2A|%2B|%2C|%2F|%3A|%3B|%3D|%3F|%40|%5B|%5D)+\\})|(?:(\\w|%20|%21|%23|%24|%25|%26|%27|%28|%29|%2A|%2B|%2C|%2F|%3A|%3B|%3D|%3F|%40|%5B|%5D)+)))*\\/?";
 
     /**
      * Given the uri returns a {@link ICompilationUnit}. May return null if it can

--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/core/JDTUtils.java
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/core/JDTUtils.java
@@ -92,6 +92,7 @@ public class JDTUtils {
     public static final String DEFAULT_PROJECT_NAME = "jdt.java-project";
 
     private static final int COMPILATION_UNIT_UPDATE_TIMEOUT = 3000;
+    // Percent encoding obtained from: https://en.wikipedia.org/wiki/Percent-encoding#Reserved_characters
     private static final String LEVEL1_URI_REGEX = "(?:\\/(?:(?:\\{(\\w|-|%20|%21|%23|%24|%25|%26|%27|%28|%29|%2A|%2B|%2C|%2F|%3A|%3B|%3D|%3F|%40|%5B|%5D)+\\})|(?:(\\w|%20|%21|%23|%24|%25|%26|%27|%28|%29|%2A|%2B|%2C|%2F|%3A|%3B|%3D|%3F|%40|%5B|%5D)+)))*\\/?";
 
     /**

--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/core/JDTUtils.java
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/core/JDTUtils.java
@@ -643,6 +643,7 @@ public class JDTUtils {
         return uriString.matches(LEVEL1_URI_REGEX);
     }
 
+    /**
      * Returns a list of all accessors (getter and setter) of the given field.
      * 
      * @param field

--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/core/websocket/WebSocketConstants.java
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/core/websocket/WebSocketConstants.java
@@ -88,6 +88,8 @@ public class WebSocketConstants {
     public static final String PARAM_TYPE_DIAG_MSG = "Invalid parameter type. When using %s, parameter must be of type: \n- %s\n- annotated with @PathParams and of type String or any Java primitive type or boxed version thereof";
 
     /* Regex */
+    // Check for any URI strings that contain //, /./, or /../
     public static final String REGEX_RELATIVE_PATHS = ".*\\/\\.{0,2}\\/.*";
+    // Check that a URI string is a valid level 1 variable (wrapped in curly brackets): alpha-numeric characters, dash, or a percent encoded character
     public static final String REGEX_URI_VARIABLE = "\\{(\\w|-|%20|%21|%23|%24|%25|%26|%27|%28|%29|%2A|%2B|%2C|%2F|%3A|%3B|%3D|%3F|%40|%5B|%5D)+\\}";
 }

--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/core/websocket/WebSocketConstants.java
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/core/websocket/WebSocketConstants.java
@@ -89,5 +89,5 @@ public class WebSocketConstants {
 
     /* Regex */
     public static final String REGEX_RELATIVE_PATHS = ".*\\/\\.{0,2}\\/.*";
-    public static final String REGEX_URI_VARIABLE = "\\{(\\w|%20|%21|%23|%24|%25|%26|%27|%28|%29|%2A|%2B|%2C|%2F|%3A|%3B|%3D|%3F|%40|%5B|%5D)+\\}";
+    public static final String REGEX_URI_VARIABLE = "\\{(\\w|-|%20|%21|%23|%24|%25|%26|%27|%28|%29|%2A|%2B|%2C|%2F|%3A|%3B|%3D|%3F|%40|%5B|%5D)+\\}";
 }

--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/core/websocket/WebSocketConstants.java
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/core/websocket/WebSocketConstants.java
@@ -89,5 +89,5 @@ public class WebSocketConstants {
 
     /* Regex */
     public static final String REGEX_RELATIVE_PATHS = ".*\\/\\.{0,2}\\/.*";
-    public static final String REGEX_URI_VARIABLE = "\\{\\w+\\}";
+    public static final String REGEX_URI_VARIABLE = "\\{(\\w|%20|%21|%23|%24|%25|%26|%27|%28|%29|%2A|%2B|%2C|%2F|%3A|%3B|%3D|%3F|%40|%5B|%5D)+\\}";
 }

--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/core/websocket/WebSocketConstants.java
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/core/websocket/WebSocketConstants.java
@@ -43,21 +43,26 @@ public class WebSocketConstants {
 
     public static final String DIAGNOSTIC_PATH_PARAMS_ANNOT_MISSING = "Parameters of type String, any Java primitive type, or boxed version thereof must be annotated with @PathParams.";
     public static final String DIAGNOSTIC_CODE_PATH_PARMS_ANNOT = "AddPathParamsAnnotation";
-    
+
     /* Diagnostic codes */
     public static final String DIAGNOSTIC_CODE_ON_OPEN_INVALID_PARAMS = "OnOpenChangeInvalidParam";
     public static final String DIAGNOSTIC_CODE_ON_CLOSE_INVALID_PARAMS = "OnCloseChangeInvalidParam";
 
-    
+    public static final String DIAGNOSTIC_SERVER_ENDPOINT_NO_SLASH = "Server endpoint paths must start with a leading '/'.";
+    public static final String DIAGNOSTIC_SERVER_ENDPOINT_NOT_LEVEL1 = "Server endpoint paths must be a URI-template (level-1) or a partial URI.";
+    public static final String DIAGNOSTIC_SERVER_ENDPOINT_RELATIVE = "Server endpoint paths must not contain the sequences /../, /./ or //.";
+    public static final String DIAGNOSTIC_SERVER_ENDPOINT_DUPLICATE_VAR = "Server endpoint paths must not use the same variable more than once in a path.";
+    public static final String DIAGNOSTIC_SERVER_ENDPOINT= "ChangeInvalidServerEndpoint";
+
     /* https://jakarta.ee/specifications/websocket/2.0/websocket-spec-2.0.html#applications */
     // Class Level Annotations
     public static final String SERVER_ENDPOINT_ANNOTATION = "ServerEndpoint";
     public static final String CLIENT_ENDPOINT_ANNOTATION = "ClientEndpoint";
-    
+
     // Superclass
     public static final String ENDPOINT_SUPERCLASS = "Endpoint";
     public static final String IS_SUPERCLASS = "isSuperclass";
-    
+
     public static final Set<String> WS_ANNOTATION_CLASS = new HashSet<>(Arrays.asList(SERVER_ENDPOINT_ANNOTATION, CLIENT_ENDPOINT_ANNOTATION));
 
     /* Annotations */
@@ -81,4 +86,8 @@ public class WebSocketConstants {
 
     // Messages
     public static final String PARAM_TYPE_DIAG_MSG = "Invalid parameter type. When using %s, parameter must be of type: \n- %s\n- annotated with @PathParams and of type String or any Java primitive type or boxed version thereof";
+
+    /* Regex */
+    public static final String REGEX_RELATIVE_PATHS = ".*\\/\\.{0,2}\\/.*";
+    public static final String REGEX_URI_VARIABLE = "\\{\\w+\\}";
 }

--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/core/websocket/WebSocketConstants.java
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/core/websocket/WebSocketConstants.java
@@ -50,7 +50,7 @@ public class WebSocketConstants {
 
     public static final String DIAGNOSTIC_SERVER_ENDPOINT_NO_SLASH = "Server endpoint paths must start with a leading '/'.";
     public static final String DIAGNOSTIC_SERVER_ENDPOINT_NOT_LEVEL1 = "Server endpoint paths must be a URI-template (level-1) or a partial URI.";
-    public static final String DIAGNOSTIC_SERVER_ENDPOINT_RELATIVE = "Server endpoint paths must not contain the sequences /../, /./ or //.";
+    public static final String DIAGNOSTIC_SERVER_ENDPOINT_RELATIVE = "Server endpoint paths must not contain the sequences '/../', '/./' or '//'.";
     public static final String DIAGNOSTIC_SERVER_ENDPOINT_DUPLICATE_VAR = "Server endpoint paths must not use the same variable more than once in a path.";
     public static final String DIAGNOSTIC_SERVER_ENDPOINT= "ChangeInvalidServerEndpoint";
 

--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/core/websocket/WebSocketDiagnosticsCollector.java
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/core/websocket/WebSocketDiagnosticsCollector.java
@@ -87,7 +87,7 @@ public class WebSocketDiagnosticsCollector implements DiagnosticsCollector {
                     // PathParam URI Mismatch Warning Diagnostic
                     uriMismatchWarningCheck(type, diagnostics, unit);
                     // ServerEndpoint annotation diagnostics
-                    serverEndpointWarningCheck(type, diagnostics, unit);
+                    serverEndpointErrorCheck(type, diagnostics, unit);
                 }
             }
         } catch (JavaModelException e) {
@@ -199,9 +199,9 @@ public class WebSocketDiagnosticsCollector implements DiagnosticsCollector {
     }
 
     /**
-     * Create a warning diagnostic if a ServerEndpoint annotation does not follow the rules.
+     * Create an error diagnostic if a ServerEndpoint annotation does not follow the rules.
      */
-    private void serverEndpointWarningCheck(IType type, List<Diagnostic> diagnostics, ICompilationUnit unit) throws JavaModelException {
+    private void serverEndpointErrorCheck(IType type, List<Diagnostic> diagnostics, ICompilationUnit unit) throws JavaModelException {
         for (IAnnotation annotation : type.getAnnotations()) {
             if (annotation.getElementName().equals(WebSocketConstants.SERVER_ENDPOINT_ANNOTATION)) {
                 for (IMemberValuePair annotationMemberValuePair : annotation.getMemberValuePairs()) {

--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/core/websocket/WebSocketDiagnosticsCollector.java
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/core/websocket/WebSocketDiagnosticsCollector.java
@@ -225,14 +225,14 @@ public class WebSocketDiagnosticsCollector implements DiagnosticsCollector {
                             WebSocketConstants.DIAGNOSTIC_SERVER_ENDPOINT_NO_SLASH,
                             WebSocketConstants.DIAGNOSTIC_SERVER_ENDPOINT);
                     diagnostics.add(diagnostic);
-                } else if (!JDTUtils.isValidLevel1URI(path)) {
-                    diagnostic = createDiagnostic(annotation, unit,
-                            WebSocketConstants.DIAGNOSTIC_SERVER_ENDPOINT_NOT_LEVEL1,
-                            WebSocketConstants.DIAGNOSTIC_SERVER_ENDPOINT);
-                    diagnostics.add(diagnostic);
                 } else if (hasRelativePathURIs(path)) {
                     diagnostic = createDiagnostic(annotation, unit,
                             WebSocketConstants.DIAGNOSTIC_SERVER_ENDPOINT_RELATIVE,
+                            WebSocketConstants.DIAGNOSTIC_SERVER_ENDPOINT);
+                    diagnostics.add(diagnostic);
+                } else if (!JDTUtils.isValidLevel1URI(path)) {
+                    diagnostic = createDiagnostic(annotation, unit,
+                            WebSocketConstants.DIAGNOSTIC_SERVER_ENDPOINT_NOT_LEVEL1,
                             WebSocketConstants.DIAGNOSTIC_SERVER_ENDPOINT);
                     diagnostics.add(diagnostic);
                 } else if (hasDuplicateURIVariables(path)) {

--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/core/websocket/WebSocketDiagnosticsCollector.java
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/core/websocket/WebSocketDiagnosticsCollector.java
@@ -88,10 +88,12 @@ public class WebSocketDiagnosticsCollector implements DiagnosticsCollector {
                 // checks if the class uses annotation to create a WebSocket endpoint
                 if (checkWSEnd.get(WebSocketConstants.IS_ANNOTATION)) {
                     // WebSocket Invalid Parameters Diagnostic
-                    invalidParamsCheck(type, WebSocketConstants.ON_OPEN, WebSocketConstants.ON_OPEN_PARAM_OPT_TYPES, 
-                            WebSocketConstants.RAW_ON_OPEN_PARAM_OPT_TYPES, WebSocketConstants.DIAGNOSTIC_CODE_ON_OPEN_INVALID_PARAMS, unit, diagnostics);
-                    invalidParamsCheck(type, WebSocketConstants.ON_CLOSE, WebSocketConstants.ON_CLOSE_PARAM_OPT_TYPES, 
-                            WebSocketConstants.RAW_ON_CLOSE_PARAM_OPT_TYPES, WebSocketConstants.DIAGNOSTIC_CODE_ON_CLOSE_INVALID_PARAMS, unit, diagnostics);
+                    invalidParamsCheck(type, WebSocketConstants.ON_OPEN, WebSocketConstants.ON_OPEN_PARAM_OPT_TYPES,
+                            WebSocketConstants.RAW_ON_OPEN_PARAM_OPT_TYPES,
+                            WebSocketConstants.DIAGNOSTIC_CODE_ON_OPEN_INVALID_PARAMS, unit, diagnostics);
+                    invalidParamsCheck(type, WebSocketConstants.ON_CLOSE, WebSocketConstants.ON_CLOSE_PARAM_OPT_TYPES,
+                            WebSocketConstants.RAW_ON_CLOSE_PARAM_OPT_TYPES,
+                            WebSocketConstants.DIAGNOSTIC_CODE_ON_CLOSE_INVALID_PARAMS, unit, diagnostics);
 
                     // PathParam URI Mismatch Warning Diagnostic
                     uriMismatchWarningCheck(type, diagnostics, unit);
@@ -102,7 +104,8 @@ public class WebSocketDiagnosticsCollector implements DiagnosticsCollector {
         }
     }
 
-    private void invalidParamsCheck(IType type, String methodAnnotTarget, Set<String> specialParamTypes, Set<String> rawSpecialParamTypes, String diagnosticCode, ICompilationUnit unit,
+    private void invalidParamsCheck(IType type, String methodAnnotTarget, Set<String> specialParamTypes,
+            Set<String> rawSpecialParamTypes, String diagnosticCode, ICompilationUnit unit,
             List<Diagnostic> diagnostics) throws JavaModelException {
 
         IMethod[] allMethods = type.getMethods();
@@ -313,9 +316,18 @@ public class WebSocketDiagnosticsCollector implements DiagnosticsCollector {
         return wsEndpoint;
     }
 
-
     private String createParamTypeDiagMsg(Set<String> methodParamOptTypes, String methodAnnotTarget) {
         String paramMessage = String.join("\n- ", methodParamOptTypes);
         return String.format(WebSocketConstants.PARAM_TYPE_DIAG_MSG, "@" + methodAnnotTarget, paramMessage);
+    }
+
+    /**
+     * Verify that a URI string does not contain any sequence with //, /./, or /../
+     *
+     * @param uriString
+     * @return
+     */
+    private boolean hasNoRelativePathURIs(String uriString) {
+        return uriString.matches("\\/\\.{0,2}\\/");
     }
 }

--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/core/websocket/WebSocketDiagnosticsCollector.java
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/core/websocket/WebSocketDiagnosticsCollector.java
@@ -98,6 +98,7 @@ public class WebSocketDiagnosticsCollector implements DiagnosticsCollector {
 
                     // PathParam URI Mismatch Warning Diagnostic
                     uriMismatchWarningCheck(type, diagnostics, unit);
+                    // ServerEndpoint annotation diagnostics
                     serverEndpointWarningCheck(type, diagnostics, unit);
                 }
             }
@@ -209,7 +210,7 @@ public class WebSocketDiagnosticsCollector implements DiagnosticsCollector {
         }
     }
 
-    /*
+    /**
      * Create a warning diagnostic if a ServerEndpoint annotation does not follow the rules.
      */
     private void serverEndpointWarningCheck(IType type, List<Diagnostic> diagnostics, ICompilationUnit unit) throws JavaModelException {
@@ -362,18 +363,18 @@ public class WebSocketDiagnosticsCollector implements DiagnosticsCollector {
     /**
      * Check if a URI string contains any sequence with //, /./, or /../
      *
-     * @param uriString
-     * @return
+     * @param uriString ServerEndpoint URI
+     * @return if a URI has a relative path
      */
     private boolean hasRelativePathURIs(String uriString) {
         return uriString.matches(WebSocketConstants.REGEX_RELATIVE_PATHS);
     }
 
-    /*
+    /**
      * Check if a URI string has a duplicate variable
      * 
-     * @param uriString
-     * @return
+     * @param uriString ServerEndpoint URI
+     * @return if a URI has duplicate variables
      */
     private boolean hasDuplicateURIVariables(String uriString) {
         HashSet<String> variables = new HashSet<String>();

--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/core/websocket/WebSocketDiagnosticsCollector.java
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/core/websocket/WebSocketDiagnosticsCollector.java
@@ -23,16 +23,6 @@ import java.util.Set;
 import java.util.ArrayList;
 
 import org.eclipse.core.runtime.CoreException;
-import org.eclipse.jdt.core.IAnnotation;
-import org.eclipse.jdt.core.ICompilationUnit;
-import org.eclipse.jdt.core.IField;
-import org.eclipse.jdt.core.IJavaElement;
-import org.eclipse.jdt.core.IMethod;
-import org.eclipse.jdt.core.IType;
-import org.eclipse.jdt.core.ITypeRoot;
-import org.eclipse.jdt.core.ILocalVariable;
-import org.eclipse.jdt.core.JavaModelException;
-import org.eclipse.jdt.core.Signature;
 import org.eclipse.jdt.internal.corext.util.JavaModelUtil;
 import org.eclipse.lsp4j.Diagnostic;
 import org.eclipse.lsp4j.DiagnosticSeverity;
@@ -42,8 +32,6 @@ import org.eclipse.lsp4jakarta.jdt.core.JDTUtils;
 import org.eclipse.lsp4jakarta.jdt.core.JakartaCorePlugin;
 import org.eclipse.lsp4jakarta.jdt.core.websocket.WebSocketConstants;
 import org.eclipse.jdt.core.*;
-
-import org.eclipse.jdt.core.ISourceRange;
 import org.eclipse.lsp4jakarta.jdt.core.AnnotationUtil;
 
 import static org.eclipse.lsp4jakarta.jdt.core.TypeHierarchyUtils.doesITypeHaveSuperType;
@@ -216,31 +204,34 @@ public class WebSocketDiagnosticsCollector implements DiagnosticsCollector {
     private void serverEndpointWarningCheck(IType type, List<Diagnostic> diagnostics, ICompilationUnit unit) throws JavaModelException {
         for (IAnnotation annotation : type.getAnnotations()) {
             if (annotation.getElementName().equals(WebSocketConstants.SERVER_ENDPOINT_ANNOTATION)) {
-                String path = annotation
-                        .getMemberValuePairs()[0]
-                        .getValue()
-                        .toString();
-                Diagnostic diagnostic;
-                if (!JDTUtils.hasLeadingSlash(path)) {
-                    diagnostic = createDiagnostic(annotation, unit,
-                            WebSocketConstants.DIAGNOSTIC_SERVER_ENDPOINT_NO_SLASH,
-                            WebSocketConstants.DIAGNOSTIC_SERVER_ENDPOINT);
-                    diagnostics.add(diagnostic);
-                } else if (hasRelativePathURIs(path)) {
-                    diagnostic = createDiagnostic(annotation, unit,
-                            WebSocketConstants.DIAGNOSTIC_SERVER_ENDPOINT_RELATIVE,
-                            WebSocketConstants.DIAGNOSTIC_SERVER_ENDPOINT);
-                    diagnostics.add(diagnostic);
-                } else if (!JDTUtils.isValidLevel1URI(path)) {
-                    diagnostic = createDiagnostic(annotation, unit,
-                            WebSocketConstants.DIAGNOSTIC_SERVER_ENDPOINT_NOT_LEVEL1,
-                            WebSocketConstants.DIAGNOSTIC_SERVER_ENDPOINT);
-                    diagnostics.add(diagnostic);
-                } else if (hasDuplicateURIVariables(path)) {
-                    diagnostic = createDiagnostic(annotation, unit,
-                            WebSocketConstants.DIAGNOSTIC_SERVER_ENDPOINT_DUPLICATE_VAR,
-                            WebSocketConstants.DIAGNOSTIC_SERVER_ENDPOINT);
-                    diagnostics.add(diagnostic);
+                for (IMemberValuePair annotationMemberValuePair : annotation.getMemberValuePairs()) {
+                    if (annotationMemberValuePair.getMemberName().equals(WebSocketConstants.ANNOTATION_VALUE)) {
+                        String path = annotationMemberValuePair
+                                .getValue()
+                                .toString();
+                        Diagnostic diagnostic;
+                        if (!JDTUtils.hasLeadingSlash(path)) {
+                            diagnostic = createDiagnostic(annotation, unit,
+                                    WebSocketConstants.DIAGNOSTIC_SERVER_ENDPOINT_NO_SLASH,
+                                    WebSocketConstants.DIAGNOSTIC_SERVER_ENDPOINT);
+                            diagnostics.add(diagnostic);
+                        } else if (hasRelativePathURIs(path)) {
+                            diagnostic = createDiagnostic(annotation, unit,
+                                    WebSocketConstants.DIAGNOSTIC_SERVER_ENDPOINT_RELATIVE,
+                                    WebSocketConstants.DIAGNOSTIC_SERVER_ENDPOINT);
+                            diagnostics.add(diagnostic);
+                        } else if (!JDTUtils.isValidLevel1URI(path)) {
+                            diagnostic = createDiagnostic(annotation, unit,
+                                    WebSocketConstants.DIAGNOSTIC_SERVER_ENDPOINT_NOT_LEVEL1,
+                                    WebSocketConstants.DIAGNOSTIC_SERVER_ENDPOINT);
+                            diagnostics.add(diagnostic);
+                        } else if (hasDuplicateURIVariables(path)) {
+                            diagnostic = createDiagnostic(annotation, unit,
+                                    WebSocketConstants.DIAGNOSTIC_SERVER_ENDPOINT_DUPLICATE_VAR,
+                                    WebSocketConstants.DIAGNOSTIC_SERVER_ENDPOINT);
+                            diagnostics.add(diagnostic);
+                        }
+                    }
                 }
             }
         }

--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/core/websocket/WebSocketDiagnosticsCollector.java
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/core/websocket/WebSocketDiagnosticsCollector.java
@@ -215,7 +215,8 @@ public class WebSocketDiagnosticsCollector implements DiagnosticsCollector {
                                     WebSocketConstants.DIAGNOSTIC_SERVER_ENDPOINT_NO_SLASH,
                                     WebSocketConstants.DIAGNOSTIC_SERVER_ENDPOINT);
                             diagnostics.add(diagnostic);
-                        } else if (hasRelativePathURIs(path)) {
+                        }
+                        if (hasRelativePathURIs(path)) {
                             diagnostic = createDiagnostic(annotation, unit,
                                     WebSocketConstants.DIAGNOSTIC_SERVER_ENDPOINT_RELATIVE,
                                     WebSocketConstants.DIAGNOSTIC_SERVER_ENDPOINT);
@@ -225,7 +226,8 @@ public class WebSocketDiagnosticsCollector implements DiagnosticsCollector {
                                     WebSocketConstants.DIAGNOSTIC_SERVER_ENDPOINT_NOT_LEVEL1,
                                     WebSocketConstants.DIAGNOSTIC_SERVER_ENDPOINT);
                             diagnostics.add(diagnostic);
-                        } else if (hasDuplicateURIVariables(path)) {
+                        }
+                        if (hasDuplicateURIVariables(path)) {
                             diagnostic = createDiagnostic(annotation, unit,
                                     WebSocketConstants.DIAGNOSTIC_SERVER_ENDPOINT_DUPLICATE_VAR,
                                     WebSocketConstants.DIAGNOSTIC_SERVER_ENDPOINT);

--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.test/projects/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/websocket/ServerEndpointDuplicateVariableURI.java
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.test/projects/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/websocket/ServerEndpointDuplicateVariableURI.java
@@ -2,5 +2,7 @@ package src.main.java.io.openliberty.sample.jakarta.websocket;
 
 import jakarta.websocket.server.ServerEndpoint;
 
+// Diagnostics:
+// + Server endpoint paths must not use the same variable more than once in a path.
 @ServerEndpoint("/{varA}/{varB}/{varA}")
 public class ServerEndpointDuplicateVariableURI {}

--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.test/projects/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/websocket/ServerEndpointDuplicateVariableURI.java
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.test/projects/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/websocket/ServerEndpointDuplicateVariableURI.java
@@ -1,0 +1,6 @@
+package src.main.java.io.openliberty.sample.jakarta.websocket;
+
+import jakarta.websocket.server.ServerEndpoint;
+
+@ServerEndpoint("/{varA}/{varB}/{varA}")
+public class ServerEndpointDuplicateVariableURI {}

--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.test/projects/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/websocket/ServerEndpointInvalidTemplateURI.java
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.test/projects/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/websocket/ServerEndpointInvalidTemplateURI.java
@@ -2,5 +2,7 @@ package src.main.java.io.openliberty.sample.jakarta.websocket;
 
 import jakarta.websocket.server.ServerEndpoint;
 
+// Diagnostics:
+// + Server endpoint paths must be a URI-template (level-1) or a partial URI.
 @ServerEndpoint("/{very incorrect variable}/")
 public class ServerEndpointInvalidTemplateURI {}

--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.test/projects/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/websocket/ServerEndpointInvalidTemplateURI.java
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.test/projects/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/websocket/ServerEndpointInvalidTemplateURI.java
@@ -1,0 +1,6 @@
+package src.main.java.io.openliberty.sample.jakarta.websocket;
+
+import jakarta.websocket.server.ServerEndpoint;
+
+@ServerEndpoint("/{very incorrect variable}/")
+public class ServerEndpointInvalidTemplateURI {}

--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.test/projects/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/websocket/ServerEndpointNoSlash.java
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.test/projects/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/websocket/ServerEndpointNoSlash.java
@@ -1,0 +1,6 @@
+package src.main.java.io.openliberty.sample.jakarta.websocket;
+
+import jakarta.websocket.server.ServerEndpoint;
+
+@ServerEndpoint("path")
+public class ServerEndpointNoSlash {}

--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.test/projects/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/websocket/ServerEndpointNoSlash.java
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.test/projects/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/websocket/ServerEndpointNoSlash.java
@@ -2,5 +2,8 @@ package src.main.java.io.openliberty.sample.jakarta.websocket;
 
 import jakarta.websocket.server.ServerEndpoint;
 
+// Diagnostics:
+// + Server endpoint paths must start with a leading '/'.
+// + Server endpoint paths must be a URI-template (level-1) or a partial URI.
 @ServerEndpoint("path")
 public class ServerEndpointNoSlash {}

--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.test/projects/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/websocket/ServerEndpointRelativePathTest.java
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.test/projects/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/websocket/ServerEndpointRelativePathTest.java
@@ -2,5 +2,7 @@ package src.main.java.io.openliberty.sample.jakarta.websocket;
 
 import jakarta.websocket.server.ServerEndpoint;
 
+// Diagnostics:
+// + Server endpoint paths must not contain the sequences '/../', '/./' or '//'.
 @ServerEndpoint("/../path")
 public class ServerEndpointRelativePathTest {}

--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.test/projects/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/websocket/ServerEndpointRelativePathTest.java
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.test/projects/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/websocket/ServerEndpointRelativePathTest.java
@@ -1,0 +1,6 @@
+package src.main.java.io.openliberty.sample.jakarta.websocket;
+
+import jakarta.websocket.server.ServerEndpoint;
+
+@ServerEndpoint("/../path")
+public class ServerEndpointRelativePathTest {}

--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.test/src/main/java/org/eclipse/lsp4jakarta/jdt/websocket/JakartaWebSocketTest.java
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.test/src/main/java/org/eclipse/lsp4jakarta/jdt/websocket/JakartaWebSocketTest.java
@@ -108,7 +108,7 @@ public class JakartaWebSocketTest extends BaseJakartaTest {
 
         JakartaDiagnosticsParams diagnosticsParams = new JakartaDiagnosticsParams();
         diagnosticsParams.setUris(Arrays.asList(uri));
-        Diagnostic d = d(4, 17, 26,
+        Diagnostic d = d(4, 0, 27,
                 "Server endpoint paths must not contain the sequences /../, /./ or //.",
                 DiagnosticSeverity.Error, "jakarta-websocket", "ChangeInvalidServerEndpoint");
 
@@ -124,7 +124,7 @@ public class JakartaWebSocketTest extends BaseJakartaTest {
 
         JakartaDiagnosticsParams diagnosticsParams = new JakartaDiagnosticsParams();
         diagnosticsParams.setUris(Arrays.asList(uri));
-        Diagnostic d = d(4, 17, 22,
+        Diagnostic d = d(4, 0, 23,
                 "Server endpoint paths must start with a leading '/'.",
                 DiagnosticSeverity.Error, "jakarta-websocket", "ChangeInvalidServerEndpoint");
 
@@ -140,7 +140,7 @@ public class JakartaWebSocketTest extends BaseJakartaTest {
 
         JakartaDiagnosticsParams diagnosticsParams = new JakartaDiagnosticsParams();
         diagnosticsParams.setUris(Arrays.asList(uri));
-        Diagnostic d = d(4, 17, 45,
+        Diagnostic d = d(4, 0, 46,
                 "Server endpoint paths must be a URI-template (level-1) or a partial URI.",
                 DiagnosticSeverity.Error, "jakarta-websocket", "ChangeInvalidServerEndpoint");
 
@@ -156,7 +156,7 @@ public class JakartaWebSocketTest extends BaseJakartaTest {
 
         JakartaDiagnosticsParams diagnosticsParams = new JakartaDiagnosticsParams();
         diagnosticsParams.setUris(Arrays.asList(uri));
-        Diagnostic d = d(4, 17, 39,
+        Diagnostic d = d(4, 0, 40,
                 "Server endpoint paths must not use the same variable more than once in a path.",
                 DiagnosticSeverity.Error, "jakarta-websocket", "ChangeInvalidServerEndpoint");
 

--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.test/src/main/java/org/eclipse/lsp4jakarta/jdt/websocket/JakartaWebSocketTest.java
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.test/src/main/java/org/eclipse/lsp4jakarta/jdt/websocket/JakartaWebSocketTest.java
@@ -108,7 +108,7 @@ public class JakartaWebSocketTest extends BaseJakartaTest {
 
         JakartaDiagnosticsParams diagnosticsParams = new JakartaDiagnosticsParams();
         diagnosticsParams.setUris(Arrays.asList(uri));
-        Diagnostic d = d(4, 0, 27,
+        Diagnostic d = d(6, 0, 27,
                 "Server endpoint paths must not contain the sequences '/../', '/./' or '//'.",
                 DiagnosticSeverity.Error, "jakarta-websocket", "ChangeInvalidServerEndpoint");
 
@@ -124,10 +124,10 @@ public class JakartaWebSocketTest extends BaseJakartaTest {
 
         JakartaDiagnosticsParams diagnosticsParams = new JakartaDiagnosticsParams();
         diagnosticsParams.setUris(Arrays.asList(uri));
-        Diagnostic d1 = d(4, 0, 23,
+        Diagnostic d1 = d(7, 0, 23,
                 "Server endpoint paths must start with a leading '/'.",
                 DiagnosticSeverity.Error, "jakarta-websocket", "ChangeInvalidServerEndpoint");
-        Diagnostic d2 = d(4, 0, 23,
+        Diagnostic d2 = d(7, 0, 23,
                 "Server endpoint paths must be a URI-template (level-1) or a partial URI.",
                 DiagnosticSeverity.Error, "jakarta-websocket", "ChangeInvalidServerEndpoint");
 
@@ -143,7 +143,7 @@ public class JakartaWebSocketTest extends BaseJakartaTest {
 
         JakartaDiagnosticsParams diagnosticsParams = new JakartaDiagnosticsParams();
         diagnosticsParams.setUris(Arrays.asList(uri));
-        Diagnostic d = d(4, 0, 46,
+        Diagnostic d = d(6, 0, 46,
                 "Server endpoint paths must be a URI-template (level-1) or a partial URI.",
                 DiagnosticSeverity.Error, "jakarta-websocket", "ChangeInvalidServerEndpoint");
 
@@ -159,7 +159,7 @@ public class JakartaWebSocketTest extends BaseJakartaTest {
 
         JakartaDiagnosticsParams diagnosticsParams = new JakartaDiagnosticsParams();
         diagnosticsParams.setUris(Arrays.asList(uri));
-        Diagnostic d = d(4, 0, 40,
+        Diagnostic d = d(6, 0, 40,
                 "Server endpoint paths must not use the same variable more than once in a path.",
                 DiagnosticSeverity.Error, "jakarta-websocket", "ChangeInvalidServerEndpoint");
 

--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.test/src/main/java/org/eclipse/lsp4jakarta/jdt/websocket/JakartaWebSocketTest.java
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.test/src/main/java/org/eclipse/lsp4jakarta/jdt/websocket/JakartaWebSocketTest.java
@@ -124,11 +124,14 @@ public class JakartaWebSocketTest extends BaseJakartaTest {
 
         JakartaDiagnosticsParams diagnosticsParams = new JakartaDiagnosticsParams();
         diagnosticsParams.setUris(Arrays.asList(uri));
-        Diagnostic d = d(4, 0, 23,
+        Diagnostic d1 = d(4, 0, 23,
                 "Server endpoint paths must start with a leading '/'.",
                 DiagnosticSeverity.Error, "jakarta-websocket", "ChangeInvalidServerEndpoint");
+        Diagnostic d2 = d(4, 0, 23,
+                "Server endpoint paths must be a URI-template (level-1) or a partial URI.",
+                DiagnosticSeverity.Error, "jakarta-websocket", "ChangeInvalidServerEndpoint");
 
-        assertJavaDiagnostics(diagnosticsParams, JDT_UTILS, d);
+        assertJavaDiagnostics(diagnosticsParams, JDT_UTILS, d1, d2);
     }
 
     @Test

--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.test/src/main/java/org/eclipse/lsp4jakarta/jdt/websocket/JakartaWebSocketTest.java
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.test/src/main/java/org/eclipse/lsp4jakarta/jdt/websocket/JakartaWebSocketTest.java
@@ -98,4 +98,68 @@ public class JakartaWebSocketTest extends BaseJakartaTest {
 
         assertJavaDiagnostics(diagnosticsParams, JDT_UTILS, d);
     }
+
+    @Test
+    public void testServerEndpointRelativeURI() throws Exception {
+        IJavaProject javaProject = loadJavaProject("jakarta-sample", "");
+        IFile javaFile = javaProject.getProject().getFile(
+                new Path("src/main/java/io/openliberty/sample/jakarta/websocket/ServerEndpointRelativePathTest.java"));
+        String uri = javaFile.getLocation().toFile().toURI().toString();
+
+        JakartaDiagnosticsParams diagnosticsParams = new JakartaDiagnosticsParams();
+        diagnosticsParams.setUris(Arrays.asList(uri));
+        Diagnostic d = d(4, 17, 26,
+                "Server endpoint paths must not contain the sequences /../, /./ or //.",
+                DiagnosticSeverity.Error, "jakarta-websocket", "ChangeInvalidServerEndpoint");
+
+        assertJavaDiagnostics(diagnosticsParams, JDT_UTILS, d);
+    }
+
+    @Test
+    public void testServerEndpointNoSlashURI() throws Exception {
+        IJavaProject javaProject = loadJavaProject("jakarta-sample", "");
+        IFile javaFile = javaProject.getProject().getFile(
+                new Path("src/main/java/io/openliberty/sample/jakarta/websocket/ServerEndpointNoSlash.java"));
+        String uri = javaFile.getLocation().toFile().toURI().toString();
+
+        JakartaDiagnosticsParams diagnosticsParams = new JakartaDiagnosticsParams();
+        diagnosticsParams.setUris(Arrays.asList(uri));
+        Diagnostic d = d(4, 17, 22,
+                "Server endpoint paths must start with a leading '/'.",
+                DiagnosticSeverity.Error, "jakarta-websocket", "ChangeInvalidServerEndpoint");
+
+        assertJavaDiagnostics(diagnosticsParams, JDT_UTILS, d);
+    }
+
+    @Test
+    public void testServerEndpointInvalidTemplateURI() throws Exception {
+        IJavaProject javaProject = loadJavaProject("jakarta-sample", "");
+        IFile javaFile = javaProject.getProject().getFile(
+                new Path("src/main/java/io/openliberty/sample/jakarta/websocket/ServerEndpointInvalidTemplateURI.java"));
+        String uri = javaFile.getLocation().toFile().toURI().toString();
+
+        JakartaDiagnosticsParams diagnosticsParams = new JakartaDiagnosticsParams();
+        diagnosticsParams.setUris(Arrays.asList(uri));
+        Diagnostic d = d(4, 17, 45,
+                "Server endpoint paths must be a URI-template (level-1) or a partial URI.",
+                DiagnosticSeverity.Error, "jakarta-websocket", "ChangeInvalidServerEndpoint");
+
+        assertJavaDiagnostics(diagnosticsParams, JDT_UTILS, d);
+    }
+
+    @Test
+    public void testServerEndpointDuplicateVariableURI() throws Exception {
+        IJavaProject javaProject = loadJavaProject("jakarta-sample", "");
+        IFile javaFile = javaProject.getProject().getFile(
+                new Path("src/main/java/io/openliberty/sample/jakarta/websocket/ServerEndpointDuplicateVariableURI.java"));
+        String uri = javaFile.getLocation().toFile().toURI().toString();
+
+        JakartaDiagnosticsParams diagnosticsParams = new JakartaDiagnosticsParams();
+        diagnosticsParams.setUris(Arrays.asList(uri));
+        Diagnostic d = d(4, 17, 39,
+                "Server endpoint paths must not use the same variable more than once in a path.",
+                DiagnosticSeverity.Error, "jakarta-websocket", "ChangeInvalidServerEndpoint");
+
+        assertJavaDiagnostics(diagnosticsParams, JDT_UTILS, d);
+    }
 }

--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.test/src/main/java/org/eclipse/lsp4jakarta/jdt/websocket/JakartaWebSocketTest.java
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.test/src/main/java/org/eclipse/lsp4jakarta/jdt/websocket/JakartaWebSocketTest.java
@@ -109,7 +109,7 @@ public class JakartaWebSocketTest extends BaseJakartaTest {
         JakartaDiagnosticsParams diagnosticsParams = new JakartaDiagnosticsParams();
         diagnosticsParams.setUris(Arrays.asList(uri));
         Diagnostic d = d(4, 0, 27,
-                "Server endpoint paths must not contain the sequences /../, /./ or //.",
+                "Server endpoint paths must not contain the sequences '/../', '/./' or '//'.",
                 DiagnosticSeverity.Error, "jakarta-websocket", "ChangeInvalidServerEndpoint");
 
         assertJavaDiagnostics(diagnosticsParams, JDT_UTILS, d);


### PR DESCRIPTION
Resolves #240 
Create methods to:
+ Verify URIs have a leading slash (done in #263)
+ Verify that a URI is following a valid URI template (level 1)
+ Verify that a URI is not using duplicate variables
+ Verify that URIs are not using relative paths

These first two methods are located in JDTUtils so that other packages can access them for ease of use.