### PR TITLE
Add method to verify URIs have a leading slash

### DIFF
--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/core/JDTUtils.java
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/core/JDTUtils.java
@@ -615,4 +615,14 @@ public class JDTUtils {
         }
         return null;
     }
+
+    /**
+     * Check if a URI starts with a leading slash.
+     *
+     * @param uriString
+     * @return boolean
+     */
+    public static boolean hasLeadingSlash(String uriString) {
+        return uriString.startsWith("/");
+    }
 }


### PR DESCRIPTION
This is needed for #240 and #242.

This PR creates a method in JDTUtils for checking if a string starts with a `/`.