### PR TITLE
add diagnostics for duplicate onMessage methods

### DIFF
--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/core/websocket/WebSocketConstants.java
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/core/websocket/WebSocketConstants.java
@@ -40,7 +40,6 @@ public class WebSocketConstants {
     public static final String URI_SEPARATOR = "/";
     public static final String CURLY_BRACE_START = "{";
     public static final String CURLY_BRACE_END = "}";
-    public static final String PERIOD = ".";
 
     public static final String DIAGNOSTIC_PATH_PARAMS_ANNOT_MISSING = "Parameters of type String, any Java primitive type, or boxed version thereof must be annotated with @PathParams.";
     public static final String DIAGNOSTIC_CODE_PATH_PARMS_ANNOT = "AddPathParamsAnnotation";
@@ -73,15 +72,20 @@ public class WebSocketConstants {
     public static final Set<String> WS_ANNOTATION_CLASS = new HashSet<>(
             Arrays.asList(SERVER_ENDPOINT_ANNOTATION, CLIENT_ENDPOINT_ANNOTATION));
 
-    public static final String STRING_CLASS = "java.lang.String";
-    public static final String READER_CLASS = "java.io.Reader";
-    public static final String BYTEBUFFER_CLASS = "java.nio.ByteBuffer";
-    public static final String INPUTSTREAM_CLASS = "java.io.InputStream";
-    public static final String PONGMESSAGE_CLASS = "jakarta.websocket.PongMessage";
+    public static final String STRING_CLASS_LONG = "java.lang.String";
+    public static final String STRING_CLASS_SHORT = "String";
+    public static final String READER_CLASS_LONG = "java.io.Reader";
+    public static final String READER_CLASS_SHORT = "Reader";
+    public static final String BYTEBUFFER_CLASS_LONG = "java.nio.ByteBuffer";
+    public static final String BYTEBUFFER_CLASS_SHORT = "ByteBuffer";
+    public static final String INPUTSTREAM_CLASS_LONG = "java.io.InputStream";
+    public static final String INPUTSTREAM_CLASS_SHORT = "InputStream";
+    public static final String PONGMESSAGE_CLASS_LONG = "jakarta.websocket.PongMessage";
+    public static final String PONGMESSAGE_CLASS_SHORT = "PongMessage";
     public static final Set<String> LONG_MESSAGE_CLASSES = new HashSet<>(
-            Arrays.asList(STRING_CLASS, READER_CLASS, BYTEBUFFER_CLASS, INPUTSTREAM_CLASS, PONGMESSAGE_CLASS));
-    public static final Set<String> SHORT_MESSAGE_CLASSES = LONG_MESSAGE_CLASSES.stream()
-            .map(longName -> longName.split(PERIOD)[2]).collect(Collectors.toSet());
+            Arrays.asList(STRING_CLASS_LONG, READER_CLASS_LONG, BYTEBUFFER_CLASS_LONG, INPUTSTREAM_CLASS_LONG, PONGMESSAGE_CLASS_LONG));
+    public static final Set<String> SHORT_MESSAGE_CLASSES = new HashSet<>(
+            Arrays.asList(STRING_CLASS_SHORT, READER_CLASS_SHORT, BYTEBUFFER_CLASS_SHORT, INPUTSTREAM_CLASS_SHORT, PONGMESSAGE_CLASS_SHORT));
     public static final String SESSION_CLASS = "jakarta.websocket.Session";
 
     /* Annotations */

--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/core/websocket/WebSocketConstants.java
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/core/websocket/WebSocketConstants.java
@@ -40,6 +40,7 @@ public class WebSocketConstants {
     public static final String URI_SEPARATOR = "/";
     public static final String CURLY_BRACE_START = "{";
     public static final String CURLY_BRACE_END = "}";
+    public static final String PERIOD = ".";
 
     public static final String DIAGNOSTIC_PATH_PARAMS_ANNOT_MISSING = "Parameters of type String, any Java primitive type, or boxed version thereof must be annotated with @PathParams.";
     public static final String DIAGNOSTIC_CODE_PATH_PARMS_ANNOT = "AddPathParamsAnnotation";
@@ -77,8 +78,10 @@ public class WebSocketConstants {
     public static final String BYTEBUFFER_CLASS = "java.nio.ByteBuffer";
     public static final String INPUTSTREAM_CLASS = "java.io.InputStream";
     public static final String PONGMESSAGE_CLASS = "jakarta.websocket.PongMessage";
-    public static final Set<String> MESSAGE_CLASSES = new HashSet<>(
+    public static final Set<String> LONG_MESSAGE_CLASSES = new HashSet<>(
             Arrays.asList(STRING_CLASS, READER_CLASS, BYTEBUFFER_CLASS, INPUTSTREAM_CLASS, PONGMESSAGE_CLASS));
+    public static final Set<String> SHORT_MESSAGE_CLASSES = LONG_MESSAGE_CLASSES.stream()
+            .map(longName -> longName.split(PERIOD)[2]).collect(Collectors.toSet());
     public static final String SESSION_CLASS = "jakarta.websocket.Session";
 
     /* Annotations */

--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/core/websocket/WebSocketConstants.java
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/core/websocket/WebSocketConstants.java
@@ -77,6 +77,8 @@ public class WebSocketConstants {
     public static final String BYTEBUFFER_CLASS = "java.nio.ByteBuffer";
     public static final String INPUTSTREAM_CLASS = "java.io.InputStream";
     public static final String PONGMESSAGE_CLASS = "jakarta.websocket.PongMessage";
+    public static final Set<String> MESSAGE_CLASSES = new HashSet<>(
+            Arrays.asList(STRING_CLASS, READER_CLASS, BYTEBUFFER_CLASS, INPUTSTREAM_CLASS, PONGMESSAGE_CLASS));
     public static final String SESSION_CLASS = "jakarta.websocket.Session";
 
     /* Annotations */

--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/core/websocket/WebSocketConstants.java
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/core/websocket/WebSocketConstants.java
@@ -48,7 +48,7 @@ public class WebSocketConstants {
     public static final String DIAGNOSTIC_CODE_ON_OPEN_INVALID_PARAMS = "OnOpenChangeInvalidParam";
     public static final String DIAGNOSTIC_CODE_ON_CLOSE_INVALID_PARAMS = "OnCloseChangeInvalidParam";
 
-    public static final String DIAGNOSTIC_ON_MESSAGE_DUPLICATE_METHOD = "Classes annotated with @ServerEndpoint may only have one @OnMessage annotated method for each of the native WebSocket message formats: text, binary and pong.";
+    public static final String DIAGNOSTIC_ON_MESSAGE_DUPLICATE_METHOD = "Classes annotated with @ServerEndpoint or @ClientEndpoint may only have one @OnMessage annotated method for each of the native WebSocket message formats: text, binary and pong.";
     public static final String DIAGNOSTIC_CODE_ON_MESSAGE_DUPLICATE_METHOD = "OnMessageDuplicateMethod";
 
     public static final String DIAGNOSTIC_SERVER_ENDPOINT_NO_SLASH = "Server endpoint paths must start with a leading '/'.";

--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/core/websocket/WebSocketConstants.java
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/core/websocket/WebSocketConstants.java
@@ -48,7 +48,7 @@ public class WebSocketConstants {
     public static final String DIAGNOSTIC_CODE_ON_OPEN_INVALID_PARAMS = "OnOpenChangeInvalidParam";
     public static final String DIAGNOSTIC_CODE_ON_CLOSE_INVALID_PARAMS = "OnCloseChangeInvalidParam";
 
-    public static final String DIAGNOSTIC_ON_MESSAGE_DUPLICATE_METHOD = "Each WebSocket endpoint may only have one message handling method for each of the native WebSocket message formats: text, binary and pong.";
+    public static final String DIAGNOSTIC_ON_MESSAGE_DUPLICATE_METHOD = "Classes annotated with @ServerEndpoint may only have one @OnMessage annotated method for each of the native WebSocket message formats: text, binary and pong.";
     public static final String DIAGNOSTIC_CODE_ON_MESSAGE_DUPLICATE_METHOD = "OnMessageDuplicateMethod";
 
     public static final String DIAGNOSTIC_SERVER_ENDPOINT_NO_SLASH = "Server endpoint paths must start with a leading '/'.";

--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/core/websocket/WebSocketConstants.java
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/core/websocket/WebSocketConstants.java
@@ -48,6 +48,9 @@ public class WebSocketConstants {
     public static final String DIAGNOSTIC_CODE_ON_OPEN_INVALID_PARAMS = "OnOpenChangeInvalidParam";
     public static final String DIAGNOSTIC_CODE_ON_CLOSE_INVALID_PARAMS = "OnCloseChangeInvalidParam";
 
+    public static final String DIAGNOSTIC_ON_MESSAGE_DUPLICATE_METHOD = "Each WebSocket endpoint may only have one message handling method for each of the native WebSocket message formats: text, binary and pong.";
+    public static final String DIAGNOSTIC_CODE_ON_MESSAGE_DUPLICATE_METHOD = "OnMessageDuplicateMethod";
+
     
     /* https://jakarta.ee/specifications/websocket/2.0/websocket-spec-2.0.html#applications */
     // Class Level Annotations
@@ -57,12 +60,20 @@ public class WebSocketConstants {
     // Superclass
     public static final String ENDPOINT_SUPERCLASS = "Endpoint";
     public static final String IS_SUPERCLASS = "isSuperclass";
-    
+
     public static final Set<String> WS_ANNOTATION_CLASS = new HashSet<>(Arrays.asList(SERVER_ENDPOINT_ANNOTATION, CLIENT_ENDPOINT_ANNOTATION));
+
+    public static final String STRING_CLASS = "java.lang.String";
+    public static final String READER_CLASS = "java.io.Reader";
+    public static final String BYTEBUFFER_CLASS = "java.nio.ByteBuffer";
+    public static final String INPUTSTREAM_CLASS = "java.io.InputStream";
+    public static final String PONGMESSAGE_CLASS = "jakarta.websocket.PongMessage";
+    public static final String SESSION_CLASS = "jakarta.websocket.Session";
 
     /* Annotations */
     public static final String ON_OPEN = "OnOpen";
     public static final String ON_CLOSE = "OnClose";
+    public static final String ON_MESSAGE = "OnMessage";
 
     public static final String IS_ANNOTATION = "isAnnotation";
 
@@ -70,10 +81,10 @@ public class WebSocketConstants {
     public static final String PATH_PARAM_ANNOTATION = "PathParam";
 
     // For OnOpen annotation    
-    public static final Set<String> ON_OPEN_PARAM_OPT_TYPES= new HashSet<>(Arrays.asList("jakarta.websocket.EndpointConfig", "jakarta.websocket.Session"));
+    public static final Set<String> ON_OPEN_PARAM_OPT_TYPES= new HashSet<>(Arrays.asList("jakarta.websocket.EndpointConfig", SESSION_CLASS));
     public static final Set<String> RAW_ON_OPEN_PARAM_OPT_TYPES= new HashSet<>(Arrays.asList("EndpointConfig", "Session"));
 
-    public static final Set<String> ON_CLOSE_PARAM_OPT_TYPES = new HashSet<>(Arrays.asList("jakarta.websocket.CloseReason", "jakarta.websocket.Session"));
+    public static final Set<String> ON_CLOSE_PARAM_OPT_TYPES = new HashSet<>(Arrays.asList("jakarta.websocket.CloseReason", SESSION_CLASS));
     public static final Set<String> RAW_ON_CLOSE_PARAM_OPT_TYPES = new HashSet<>(Arrays.asList("CloseReason", "Session"));
     
     public static final Set<String> RAW_WRAPPER_OBJS = new HashSet<>(Arrays.asList("String", "Boolean", "Integer", "Long", "Double", "Float"));
@@ -81,4 +92,7 @@ public class WebSocketConstants {
 
     // Messages
     public static final String PARAM_TYPE_DIAG_MSG = "Invalid parameter type. When using %s, parameter must be of type: \n- %s\n- annotated with @PathParams and of type String or any Java primitive type or boxed version thereof";
+
+    // Enums
+    public enum MESSAGE_FORMAT {TEXT, BINARY, PONG};
 }

--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/core/websocket/WebSocketDiagnosticsCollector.java
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/core/websocket/WebSocketDiagnosticsCollector.java
@@ -132,8 +132,7 @@ public class WebSocketDiagnosticsCollector implements DiagnosticsCollector {
                         // check parameters valid types
                         if (!(isSpecialType || isPrimWrapped || isPrimitive)) {
                             Diagnostic diagnostic = createDiagnostic(param, unit,
-                                    createParamTypeDiagMsg(specialParamTypes, methodAnnotTarget),
-                                    diagnosticCode);
+                                    createParamTypeDiagMsg(specialParamTypes, methodAnnotTarget), diagnosticCode);
                             diagnostics.add(diagnostic);
                             continue;
                         }
@@ -231,24 +230,24 @@ public class WebSocketDiagnosticsCollector implements DiagnosticsCollector {
                                 WebSocketConstants.MESSAGE_FORMAT messageFormat = getMessageFormat(resolvedTypeName);
                                 boolean duplicateFound = false;
                                 switch (messageFormat) {
-                                    case TEXT:
-                                        if (onMessageTextUsed) {
-                                            duplicateFound = true;
-                                        }
-                                        onMessageTextUsed = true;
-                                        break;
-                                    case BINARY:
-                                        if (onMessageBinaryUsed) {
-                                            duplicateFound = true;
-                                        }
-                                        onMessageBinaryUsed = true;
-                                        break;
-                                    case PONG:
-                                        if (onMessagePongUsed) {
-                                            duplicateFound = true;
-                                        }
-                                        onMessagePongUsed = true;
-                                        break;
+                                case TEXT:
+                                    if (onMessageTextUsed) {
+                                        duplicateFound = true;
+                                    }
+                                    onMessageTextUsed = true;
+                                    break;
+                                case BINARY:
+                                    if (onMessageBinaryUsed) {
+                                        duplicateFound = true;
+                                    }
+                                    onMessageBinaryUsed = true;
+                                    break;
+                                case PONG:
+                                    if (onMessagePongUsed) {
+                                        duplicateFound = true;
+                                    }
+                                    onMessagePongUsed = true;
+                                    break;
                                 }
                                 if (duplicateFound) {
                                     Diagnostic diagnostic = createDiagnostic(annotation, unit,
@@ -274,9 +273,7 @@ public class WebSocketDiagnosticsCollector implements DiagnosticsCollector {
             if (annotation.getElementName().equals(WebSocketConstants.SERVER_ENDPOINT_ANNOTATION)) {
                 for (IMemberValuePair annotationMemberValuePair : annotation.getMemberValuePairs()) {
                     if (annotationMemberValuePair.getMemberName().equals(WebSocketConstants.ANNOTATION_VALUE)) {
-                        String path = annotationMemberValuePair
-                                .getValue()
-                                .toString();
+                        String path = annotationMemberValuePair.getValue().toString();
                         Diagnostic diagnostic;
                         if (!JDTUtils.hasLeadingSlash(path)) {
                             diagnostic = createDiagnostic(annotation, unit,

--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/core/websocket/WebSocketDiagnosticsCollector.java
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/core/websocket/WebSocketDiagnosticsCollector.java
@@ -232,7 +232,7 @@ public class WebSocketDiagnosticsCollector implements DiagnosticsCollector {
                             String signature = param.getTypeSignature();
                             String formatSignature = signature.replace("/", ".");
                             String resolvedTypeName = JavaModelUtil.getResolvedTypeName(formatSignature, type);
-                            if (!resolvedTypeName.equals(WebSocketConstants.SESSION_CLASS)) {
+                            if (resolvedTypeName != null && !resolvedTypeName.equals(WebSocketConstants.SESSION_CLASS)) {
                                 WebSocketConstants.MESSAGE_FORMAT messageFormat = getMessageFormat(resolvedTypeName);
                                 boolean duplicateFound = false;
                                 switch (messageFormat) {

--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/core/websocket/WebSocketDiagnosticsCollector.java
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/core/websocket/WebSocketDiagnosticsCollector.java
@@ -256,7 +256,7 @@ public class WebSocketDiagnosticsCollector implements DiagnosticsCollector {
                                     break;
                                 }
                                 if (duplicateFound) {
-                                    Diagnostic diagnostic = createDiagnostic(param, unit,
+                                    Diagnostic diagnostic = createDiagnostic(annotation, unit,
                                             WebSocketConstants.DIAGNOSTIC_ON_MESSAGE_DUPLICATE_METHOD,
                                             WebSocketConstants.DIAGNOSTIC_CODE_ON_MESSAGE_DUPLICATE_METHOD);
                                     diagnostics.add(diagnostic);

--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/core/websocket/WebSocketDiagnosticsCollector.java
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/core/websocket/WebSocketDiagnosticsCollector.java
@@ -225,39 +225,52 @@ public class WebSocketDiagnosticsCollector implements DiagnosticsCollector {
                             String signature = param.getTypeSignature();
                             String formatSignature = signature.replace("/", ".");
                             String resolvedTypeName = JavaModelUtil.getResolvedTypeName(formatSignature, type);
-                            if (resolvedTypeName != null
-                                    && !resolvedTypeName.equals(WebSocketConstants.SESSION_CLASS)) {
+                            if (resolvedTypeName == null) {
+                                resolvedTypeName = Signature.getSignatureSimpleName(signature);
+                            }
+                            if (WebSocketConstants.MESSAGE_CLASSES.contains(resolvedTypeName)) {
                                 WebSocketConstants.MESSAGE_FORMAT messageFormat = getMessageFormat(resolvedTypeName);
-                                IAnnotation duplicateFound = null;
+                                Diagnostic diagnostic1, diagnostic2;
                                 switch (messageFormat) {
                                 case TEXT:
                                     if (onMessageTextUsed != null) {
-                                        duplicateFound = onMessageTextUsed;
+                                        diagnostic1 = createDiagnostic(annotation, unit,
+                                                WebSocketConstants.DIAGNOSTIC_ON_MESSAGE_DUPLICATE_METHOD,
+                                                WebSocketConstants.DIAGNOSTIC_CODE_ON_MESSAGE_DUPLICATE_METHOD);
+                                        diagnostic2 = createDiagnostic(onMessageTextUsed, unit,
+                                                WebSocketConstants.DIAGNOSTIC_ON_MESSAGE_DUPLICATE_METHOD,
+                                                WebSocketConstants.DIAGNOSTIC_CODE_ON_MESSAGE_DUPLICATE_METHOD);
+                                        diagnostics.add(diagnostic1);
+                                        diagnostics.add(diagnostic2);
                                     }
                                     onMessageTextUsed = annotation;
                                     break;
                                 case BINARY:
                                     if (onMessageBinaryUsed != null) {
-                                        duplicateFound = onMessageBinaryUsed;
+                                        diagnostic1 = createDiagnostic(annotation, unit,
+                                                WebSocketConstants.DIAGNOSTIC_ON_MESSAGE_DUPLICATE_METHOD,
+                                                WebSocketConstants.DIAGNOSTIC_CODE_ON_MESSAGE_DUPLICATE_METHOD);
+                                        diagnostic2 = createDiagnostic(onMessageBinaryUsed, unit,
+                                                WebSocketConstants.DIAGNOSTIC_ON_MESSAGE_DUPLICATE_METHOD,
+                                                WebSocketConstants.DIAGNOSTIC_CODE_ON_MESSAGE_DUPLICATE_METHOD);
+                                        diagnostics.add(diagnostic1);
+                                        diagnostics.add(diagnostic2);
                                     }
                                     onMessageBinaryUsed = annotation;
                                     break;
                                 case PONG:
                                     if (onMessagePongUsed != null) {
-                                        duplicateFound = onMessagePongUsed;
+                                        diagnostic1 = createDiagnostic(annotation, unit,
+                                                WebSocketConstants.DIAGNOSTIC_ON_MESSAGE_DUPLICATE_METHOD,
+                                                WebSocketConstants.DIAGNOSTIC_CODE_ON_MESSAGE_DUPLICATE_METHOD);
+                                        diagnostic2 = createDiagnostic(onMessagePongUsed, unit,
+                                                WebSocketConstants.DIAGNOSTIC_ON_MESSAGE_DUPLICATE_METHOD,
+                                                WebSocketConstants.DIAGNOSTIC_CODE_ON_MESSAGE_DUPLICATE_METHOD);
+                                        diagnostics.add(diagnostic1);
+                                        diagnostics.add(diagnostic2);
                                     }
                                     onMessagePongUsed = annotation;
                                     break;
-                                }
-                                if (duplicateFound != null) {
-                                    Diagnostic diagnostic1 = createDiagnostic(annotation, unit,
-                                            WebSocketConstants.DIAGNOSTIC_ON_MESSAGE_DUPLICATE_METHOD,
-                                            WebSocketConstants.DIAGNOSTIC_CODE_ON_MESSAGE_DUPLICATE_METHOD);
-                                    Diagnostic diagnostic2 = createDiagnostic(duplicateFound, unit,
-                                            WebSocketConstants.DIAGNOSTIC_ON_MESSAGE_DUPLICATE_METHOD,
-                                            WebSocketConstants.DIAGNOSTIC_CODE_ON_MESSAGE_DUPLICATE_METHOD);
-                                    diagnostics.add(diagnostic1);
-                                    diagnostics.add(diagnostic2);
                                 }
                             }
                         }

--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/core/websocket/WebSocketDiagnosticsCollector.java
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/core/websocket/WebSocketDiagnosticsCollector.java
@@ -225,10 +225,13 @@ public class WebSocketDiagnosticsCollector implements DiagnosticsCollector {
                             String signature = param.getTypeSignature();
                             String formatSignature = signature.replace("/", ".");
                             String resolvedTypeName = JavaModelUtil.getResolvedTypeName(formatSignature, type);
+                            String typeName = null;
                             if (resolvedTypeName == null) {
-                                resolvedTypeName = Signature.getSignatureSimpleName(signature);
+                                typeName = Signature.getSignatureSimpleName(signature);
                             }
-                            if (WebSocketConstants.MESSAGE_CLASSES.contains(resolvedTypeName)) {
+                            if ((resolvedTypeName != null
+                                    && WebSocketConstants.LONG_MESSAGE_CLASSES.contains(resolvedTypeName))
+                                    || WebSocketConstants.SHORT_MESSAGE_CLASSES.contains(typeName)) {
                                 WebSocketConstants.MESSAGE_FORMAT messageFormat = getMessageFormat(resolvedTypeName);
                                 Diagnostic diagnostic1, diagnostic2;
                                 switch (messageFormat) {

--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/core/websocket/WebSocketDiagnosticsCollector.java
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/core/websocket/WebSocketDiagnosticsCollector.java
@@ -232,7 +232,9 @@ public class WebSocketDiagnosticsCollector implements DiagnosticsCollector {
                             if ((resolvedTypeName != null
                                     && WebSocketConstants.LONG_MESSAGE_CLASSES.contains(resolvedTypeName))
                                     || WebSocketConstants.SHORT_MESSAGE_CLASSES.contains(typeName)) {
-                                WebSocketConstants.MESSAGE_FORMAT messageFormat = getMessageFormat(resolvedTypeName);
+                                WebSocketConstants.MESSAGE_FORMAT messageFormat = resolvedTypeName != null
+                                        ? getMessageFormat(resolvedTypeName, true)
+                                        : getMessageFormat(typeName, false);
                                 Diagnostic diagnostic1, diagnostic2;
                                 switch (messageFormat) {
                                 case TEXT:
@@ -444,17 +446,33 @@ public class WebSocketDiagnosticsCollector implements DiagnosticsCollector {
         return false;
     }
 
-    private WebSocketConstants.MESSAGE_FORMAT getMessageFormat(String typeName) {
+    private WebSocketConstants.MESSAGE_FORMAT getMessageFormat(String typeName, boolean longName) {
+        if (longName) {
+            switch (typeName) {
+            case WebSocketConstants.STRING_CLASS_LONG:
+                return WebSocketConstants.MESSAGE_FORMAT.TEXT;
+            case WebSocketConstants.READER_CLASS_LONG:
+                return WebSocketConstants.MESSAGE_FORMAT.TEXT;
+            case WebSocketConstants.BYTEBUFFER_CLASS_LONG:
+                return WebSocketConstants.MESSAGE_FORMAT.BINARY;
+            case WebSocketConstants.INPUTSTREAM_CLASS_LONG:
+                return WebSocketConstants.MESSAGE_FORMAT.BINARY;
+            case WebSocketConstants.PONGMESSAGE_CLASS_LONG:
+                return WebSocketConstants.MESSAGE_FORMAT.PONG;
+            default:
+                throw new IllegalArgumentException("Invalid message format type");
+            }
+        }
         switch (typeName) {
-        case WebSocketConstants.STRING_CLASS:
+        case WebSocketConstants.STRING_CLASS_SHORT:
             return WebSocketConstants.MESSAGE_FORMAT.TEXT;
-        case WebSocketConstants.READER_CLASS:
+        case WebSocketConstants.READER_CLASS_SHORT:
             return WebSocketConstants.MESSAGE_FORMAT.TEXT;
-        case WebSocketConstants.BYTEBUFFER_CLASS:
+        case WebSocketConstants.BYTEBUFFER_CLASS_SHORT:
             return WebSocketConstants.MESSAGE_FORMAT.BINARY;
-        case WebSocketConstants.INPUTSTREAM_CLASS:
+        case WebSocketConstants.INPUTSTREAM_CLASS_SHORT:
             return WebSocketConstants.MESSAGE_FORMAT.BINARY;
-        case WebSocketConstants.PONGMESSAGE_CLASS:
+        case WebSocketConstants.PONGMESSAGE_CLASS_SHORT:
             return WebSocketConstants.MESSAGE_FORMAT.PONG;
         default:
             throw new IllegalArgumentException("Invalid message format type");

--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/core/websocket/WebSocketDiagnosticsCollector.java
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/core/websocket/WebSocketDiagnosticsCollector.java
@@ -286,14 +286,13 @@ public class WebSocketDiagnosticsCollector implements DiagnosticsCollector {
     }
 
     /**
-     * Create an error diagnostic if a ServerEndpoint annotation does not follow the
-     * rules.
+     * Create an error diagnostic if a ServerEndpoint annotation's URI contains relative
+     * paths, missing a leading slash, or does not follow a valid level-1 template URI.
      */
     private void serverEndpointErrorCheck(IType type, List<Diagnostic> diagnostics, ICompilationUnit unit)
             throws JavaModelException {
         for (IAnnotation annotation : type.getAnnotations()) {
-            if (annotation.getElementName().equals(WebSocketConstants.SERVER_ENDPOINT_ANNOTATION)
-                    || annotation.getElementName().equals(WebSocketConstants.CLIENT_ENDPOINT_ANNOTATION)) {
+            if (annotation.getElementName().equals(WebSocketConstants.SERVER_ENDPOINT_ANNOTATION)) {
                 for (IMemberValuePair annotationMemberValuePair : annotation.getMemberValuePairs()) {
                     if (annotationMemberValuePair.getMemberName().equals(WebSocketConstants.ANNOTATION_VALUE)) {
                         String path = annotationMemberValuePair.getValue().toString();

--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/core/websocket/WebSocketDiagnosticsCollector.java
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/core/websocket/WebSocketDiagnosticsCollector.java
@@ -212,9 +212,9 @@ public class WebSocketDiagnosticsCollector implements DiagnosticsCollector {
     private void onMessageWSMessageFormats(IType type, List<Diagnostic> diagnostics, ICompilationUnit unit)
             throws JavaModelException {
         IMethod[] typeMethods = type.getMethods();
-        boolean onMessageTextUsed = false;
-        boolean onMessageBinaryUsed = false;
-        boolean onMessagePongUsed = false;
+        IAnnotation onMessageTextUsed = null;
+        IAnnotation onMessageBinaryUsed = null;
+        IAnnotation onMessagePongUsed = null;
         for (IMethod method : typeMethods) {
             IAnnotation[] allAnnotations = method.getAnnotations();
             for (IAnnotation annotation : allAnnotations) {
@@ -228,32 +228,36 @@ public class WebSocketDiagnosticsCollector implements DiagnosticsCollector {
                             if (resolvedTypeName != null
                                     && !resolvedTypeName.equals(WebSocketConstants.SESSION_CLASS)) {
                                 WebSocketConstants.MESSAGE_FORMAT messageFormat = getMessageFormat(resolvedTypeName);
-                                boolean duplicateFound = false;
+                                IAnnotation duplicateFound = null;
                                 switch (messageFormat) {
                                 case TEXT:
-                                    if (onMessageTextUsed) {
-                                        duplicateFound = true;
+                                    if (onMessageTextUsed != null) {
+                                        duplicateFound = onMessageTextUsed;
                                     }
-                                    onMessageTextUsed = true;
+                                    onMessageTextUsed = annotation;
                                     break;
                                 case BINARY:
-                                    if (onMessageBinaryUsed) {
-                                        duplicateFound = true;
+                                    if (onMessageBinaryUsed != null) {
+                                        duplicateFound = onMessageBinaryUsed;
                                     }
-                                    onMessageBinaryUsed = true;
+                                    onMessageBinaryUsed = annotation;
                                     break;
                                 case PONG:
-                                    if (onMessagePongUsed) {
-                                        duplicateFound = true;
+                                    if (onMessagePongUsed != null) {
+                                        duplicateFound = onMessagePongUsed;
                                     }
-                                    onMessagePongUsed = true;
+                                    onMessagePongUsed = annotation;
                                     break;
                                 }
-                                if (duplicateFound) {
-                                    Diagnostic diagnostic = createDiagnostic(annotation, unit,
+                                if (duplicateFound != null) {
+                                    Diagnostic diagnostic1 = createDiagnostic(annotation, unit,
                                             WebSocketConstants.DIAGNOSTIC_ON_MESSAGE_DUPLICATE_METHOD,
                                             WebSocketConstants.DIAGNOSTIC_CODE_ON_MESSAGE_DUPLICATE_METHOD);
-                                    diagnostics.add(diagnostic);
+                                    Diagnostic diagnostic2 = createDiagnostic(duplicateFound, unit,
+                                            WebSocketConstants.DIAGNOSTIC_ON_MESSAGE_DUPLICATE_METHOD,
+                                            WebSocketConstants.DIAGNOSTIC_CODE_ON_MESSAGE_DUPLICATE_METHOD);
+                                    diagnostics.add(diagnostic1);
+                                    diagnostics.add(diagnostic2);
                                 }
                             }
                         }

--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/core/websocket/WebSocketDiagnosticsCollector.java
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/core/websocket/WebSocketDiagnosticsCollector.java
@@ -270,7 +270,8 @@ public class WebSocketDiagnosticsCollector implements DiagnosticsCollector {
     private void serverEndpointErrorCheck(IType type, List<Diagnostic> diagnostics, ICompilationUnit unit)
             throws JavaModelException {
         for (IAnnotation annotation : type.getAnnotations()) {
-            if (annotation.getElementName().equals(WebSocketConstants.SERVER_ENDPOINT_ANNOTATION)) {
+            if (annotation.getElementName().equals(WebSocketConstants.SERVER_ENDPOINT_ANNOTATION)
+                    || annotation.getElementName().equals(WebSocketConstants.CLIENT_ENDPOINT_ANNOTATION)) {
                 for (IMemberValuePair annotationMemberValuePair : annotation.getMemberValuePairs()) {
                     if (annotationMemberValuePair.getMemberName().equals(WebSocketConstants.ANNOTATION_VALUE)) {
                         String path = annotationMemberValuePair.getValue().toString();

--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.test/projects/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/websocket/DuplicateOnMessage.java
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.test/projects/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/websocket/DuplicateOnMessage.java
@@ -1,0 +1,21 @@
+package src.main.java.io.openliberty.sample.jakarta.websocket;
+
+import java.io.Reader;
+
+import jakarta.websocket.OnMessage;
+import jakarta.websocket.Session;
+import jakarta.websocket.server.PathParam;
+import jakarta.websocket.server.ServerEndpoint;
+
+@ServerEndpoint("/{var}")
+public class DuplicateOnMessage {
+    @OnMessage
+    public void textHandler1(@PathParam("var") String var, String text, Session session) {
+        session.getAsyncRemote().sendText(text);
+    }
+
+    @OnMessage
+    public void textHandler2(@PathParam("var") String var, Reader text, Session session) {
+        session.getAsyncRemote().sendText(var);
+    }
+}

--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.test/projects/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/websocket/DuplicateOnMessage.java
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.test/projects/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/websocket/DuplicateOnMessage.java
@@ -7,6 +7,7 @@ import jakarta.websocket.Session;
 import jakarta.websocket.server.PathParam;
 import jakarta.websocket.server.ServerEndpoint;
 
+// String and Reader will cause a duplicate diagnostic as they're both text message formats.
 @ServerEndpoint("/{var}")
 public class DuplicateOnMessage {
     @OnMessage

--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.test/src/main/java/org/eclipse/lsp4jakarta/jdt/websocket/JakartaWebSocketTest.java
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.test/src/main/java/org/eclipse/lsp4jakarta/jdt/websocket/JakartaWebSocketTest.java
@@ -171,7 +171,7 @@ public class JakartaWebSocketTest extends BaseJakartaTest {
         JakartaDiagnosticsParams diagnosticsParams = new JakartaDiagnosticsParams();
         diagnosticsParams.setUris(Arrays.asList(uri));
         Diagnostic d = d(16, 4, 14,
-                "Each WebSocket endpoint may only have one message handling method for each of the native WebSocket message formats: text, binary and pong.",
+                "Classes annotated with @ServerEndpoint may only have one @OnMessage annotated method for each of the native WebSocket message formats: text, binary and pong.",
                 DiagnosticSeverity.Error, "jakarta-websocket", "OnMessageDuplicateMethod");
 
         assertJavaDiagnostics(diagnosticsParams, JDT_UTILS, d);

--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.test/src/main/java/org/eclipse/lsp4jakarta/jdt/websocket/JakartaWebSocketTest.java
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.test/src/main/java/org/eclipse/lsp4jakarta/jdt/websocket/JakartaWebSocketTest.java
@@ -170,10 +170,13 @@ public class JakartaWebSocketTest extends BaseJakartaTest {
 
         JakartaDiagnosticsParams diagnosticsParams = new JakartaDiagnosticsParams();
         diagnosticsParams.setUris(Arrays.asList(uri));
-        Diagnostic d = d(16, 4, 14,
+        Diagnostic d1 = d(11, 4, 14,
+                "Classes annotated with @ServerEndpoint or @ClientEndpoint may only have one @OnMessage annotated method for each of the native WebSocket message formats: text, binary and pong.",
+                DiagnosticSeverity.Error, "jakarta-websocket", "OnMessageDuplicateMethod");
+        Diagnostic d2 = d(16, 4, 14,
                 "Classes annotated with @ServerEndpoint or @ClientEndpoint may only have one @OnMessage annotated method for each of the native WebSocket message formats: text, binary and pong.",
                 DiagnosticSeverity.Error, "jakarta-websocket", "OnMessageDuplicateMethod");
 
-        assertJavaDiagnostics(diagnosticsParams, JDT_UTILS, d);
+        assertJavaDiagnostics(diagnosticsParams, JDT_UTILS, d1, d2);
     }
 }

--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.test/src/main/java/org/eclipse/lsp4jakarta/jdt/websocket/JakartaWebSocketTest.java
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.test/src/main/java/org/eclipse/lsp4jakarta/jdt/websocket/JakartaWebSocketTest.java
@@ -74,15 +74,15 @@ public class JakartaWebSocketTest extends BaseJakartaTest {
         Diagnostic d1 = d(18, 47, 59,
         "Invalid parameter type. When using @OnOpen, parameter must be of type: \n- jakarta.websocket.EndpointConfig\n- jakarta.websocket.Session\n- annotated with @PathParams and of type String or any Java primitive type or boxed version thereof",
                 DiagnosticSeverity.Error, "jakarta-websocket", "OnOpenChangeInvalidParam");
-        
+
         // OnClose Invalid Param Type
         Diagnostic d2 = d(23, 73, 85,
                 "Invalid parameter type. When using @OnClose, parameter must be of type: \n- jakarta.websocket.CloseReason\n- jakarta.websocket.Session\n- annotated with @PathParams and of type String or any Java primitive type or boxed version thereof",
                 DiagnosticSeverity.Error, "jakarta-websocket", "OnCloseChangeInvalidParam");
-        
+
         assertJavaDiagnostics(diagnosticsParams, JDT_UTILS, d1, d2);
     }
-    
+
     @Test
     public void testPathParamInvalidURI() throws Exception {
         IJavaProject javaProject = loadJavaProject("jakarta-sample", "");
@@ -109,8 +109,7 @@ public class JakartaWebSocketTest extends BaseJakartaTest {
         JakartaDiagnosticsParams diagnosticsParams = new JakartaDiagnosticsParams();
         diagnosticsParams.setUris(Arrays.asList(uri));
 
-        Diagnostic d = d(6, 0, 27,
-                "Server endpoint paths must not contain the sequences '/../', '/./' or '//'.",
+        Diagnostic d = d(6, 0, 27, "Server endpoint paths must not contain the sequences '/../', '/./' or '//'.",
                 DiagnosticSeverity.Error, "jakarta-websocket", "ChangeInvalidServerEndpoint");
 
         assertJavaDiagnostics(diagnosticsParams, JDT_UTILS, d);
@@ -119,17 +118,15 @@ public class JakartaWebSocketTest extends BaseJakartaTest {
     @Test
     public void testServerEndpointNoSlashURI() throws Exception {
         IJavaProject javaProject = loadJavaProject("jakarta-sample", "");
-        IFile javaFile = javaProject.getProject().getFile(
-                new Path("src/main/java/io/openliberty/sample/jakarta/websocket/ServerEndpointNoSlash.java"));
+        IFile javaFile = javaProject.getProject()
+                .getFile(new Path("src/main/java/io/openliberty/sample/jakarta/websocket/ServerEndpointNoSlash.java"));
         String uri = javaFile.getLocation().toFile().toURI().toString();
 
         JakartaDiagnosticsParams diagnosticsParams = new JakartaDiagnosticsParams();
         diagnosticsParams.setUris(Arrays.asList(uri));
-        Diagnostic d1 = d(7, 0, 23,
-                "Server endpoint paths must start with a leading '/'.",
-                DiagnosticSeverity.Error, "jakarta-websocket", "ChangeInvalidServerEndpoint");
-        Diagnostic d2 = d(7, 0, 23,
-                "Server endpoint paths must be a URI-template (level-1) or a partial URI.",
+        Diagnostic d1 = d(7, 0, 23, "Server endpoint paths must start with a leading '/'.", DiagnosticSeverity.Error,
+                "jakarta-websocket", "ChangeInvalidServerEndpoint");
+        Diagnostic d2 = d(7, 0, 23, "Server endpoint paths must be a URI-template (level-1) or a partial URI.",
                 DiagnosticSeverity.Error, "jakarta-websocket", "ChangeInvalidServerEndpoint");
 
         assertJavaDiagnostics(diagnosticsParams, JDT_UTILS, d1, d2);
@@ -138,14 +135,13 @@ public class JakartaWebSocketTest extends BaseJakartaTest {
     @Test
     public void testServerEndpointInvalidTemplateURI() throws Exception {
         IJavaProject javaProject = loadJavaProject("jakarta-sample", "");
-        IFile javaFile = javaProject.getProject().getFile(
-                new Path("src/main/java/io/openliberty/sample/jakarta/websocket/ServerEndpointInvalidTemplateURI.java"));
+        IFile javaFile = javaProject.getProject().getFile(new Path(
+                "src/main/java/io/openliberty/sample/jakarta/websocket/ServerEndpointInvalidTemplateURI.java"));
         String uri = javaFile.getLocation().toFile().toURI().toString();
 
         JakartaDiagnosticsParams diagnosticsParams = new JakartaDiagnosticsParams();
         diagnosticsParams.setUris(Arrays.asList(uri));
-        Diagnostic d = d(6, 0, 46,
-                "Server endpoint paths must be a URI-template (level-1) or a partial URI.",
+        Diagnostic d = d(6, 0, 46, "Server endpoint paths must be a URI-template (level-1) or a partial URI.",
                 DiagnosticSeverity.Error, "jakarta-websocket", "ChangeInvalidServerEndpoint");
 
         assertJavaDiagnostics(diagnosticsParams, JDT_UTILS, d);
@@ -154,14 +150,13 @@ public class JakartaWebSocketTest extends BaseJakartaTest {
     @Test
     public void testServerEndpointDuplicateVariableURI() throws Exception {
         IJavaProject javaProject = loadJavaProject("jakarta-sample", "");
-        IFile javaFile = javaProject.getProject().getFile(
-                new Path("src/main/java/io/openliberty/sample/jakarta/websocket/ServerEndpointDuplicateVariableURI.java"));
+        IFile javaFile = javaProject.getProject().getFile(new Path(
+                "src/main/java/io/openliberty/sample/jakarta/websocket/ServerEndpointDuplicateVariableURI.java"));
         String uri = javaFile.getLocation().toFile().toURI().toString();
 
         JakartaDiagnosticsParams diagnosticsParams = new JakartaDiagnosticsParams();
         diagnosticsParams.setUris(Arrays.asList(uri));
-        Diagnostic d = d(6, 0, 40,
-                "Server endpoint paths must not use the same variable more than once in a path.",
+        Diagnostic d = d(6, 0, 40, "Server endpoint paths must not use the same variable more than once in a path.",
                 DiagnosticSeverity.Error, "jakarta-websocket", "ChangeInvalidServerEndpoint");
 
         assertJavaDiagnostics(diagnosticsParams, JDT_UTILS, d);
@@ -169,10 +164,14 @@ public class JakartaWebSocketTest extends BaseJakartaTest {
 
     public void testDuplicateOnMessage() throws Exception {
         IJavaProject javaProject = loadJavaProject("jakarta-sample", "");
-        IFile javaFile = javaProject.getProject().getFile(
-                new Path("src/main/java/io/openliberty/sample/jakarta/websocket/DuplicateOnMessage.java"));
+        IFile javaFile = javaProject.getProject()
+                .getFile(new Path("src/main/java/io/openliberty/sample/jakarta/websocket/DuplicateOnMessage.java"));
+        String uri = javaFile.getLocation().toFile().toURI().toString();
 
-        Diagnostic d = d(16, 4, 14, "Each WebSocket endpoint may only have one message handling method for each of the native WebSocket message formats: text, binary and pong.",
+        JakartaDiagnosticsParams diagnosticsParams = new JakartaDiagnosticsParams();
+        diagnosticsParams.setUris(Arrays.asList(uri));
+        Diagnostic d = d(16, 4, 14,
+                "Each WebSocket endpoint may only have one message handling method for each of the native WebSocket message formats: text, binary and pong.",
                 DiagnosticSeverity.Error, "jakarta-websocket", "OnMessageDuplicateMethod");
 
         assertJavaDiagnostics(diagnosticsParams, JDT_UTILS, d);

--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.test/src/main/java/org/eclipse/lsp4jakarta/jdt/websocket/JakartaWebSocketTest.java
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.test/src/main/java/org/eclipse/lsp4jakarta/jdt/websocket/JakartaWebSocketTest.java
@@ -109,7 +109,7 @@ public class JakartaWebSocketTest extends BaseJakartaTest {
         JakartaDiagnosticsParams diagnosticsParams = new JakartaDiagnosticsParams();
         diagnosticsParams.setUris(Arrays.asList(uri));
 
-        Diagnostic d = d(17, 66, 70, "Each WebSocket endpoint may only have one message handling method for each of the native WebSocket message formats: text, binary and pong.",
+        Diagnostic d = d(16, 4, 14, "Each WebSocket endpoint may only have one message handling method for each of the native WebSocket message formats: text, binary and pong.",
                 DiagnosticSeverity.Error, "jakarta-websocket", "OnMessageDuplicateMethod");
 
         assertJavaDiagnostics(diagnosticsParams, JDT_UTILS, d);

--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.test/src/main/java/org/eclipse/lsp4jakarta/jdt/websocket/JakartaWebSocketTest.java
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.test/src/main/java/org/eclipse/lsp4jakarta/jdt/websocket/JakartaWebSocketTest.java
@@ -171,7 +171,7 @@ public class JakartaWebSocketTest extends BaseJakartaTest {
         JakartaDiagnosticsParams diagnosticsParams = new JakartaDiagnosticsParams();
         diagnosticsParams.setUris(Arrays.asList(uri));
         Diagnostic d = d(16, 4, 14,
-                "Classes annotated with @ServerEndpoint may only have one @OnMessage annotated method for each of the native WebSocket message formats: text, binary and pong.",
+                "Classes annotated with @ServerEndpoint or @ClientEndpoint may only have one @OnMessage annotated method for each of the native WebSocket message formats: text, binary and pong.",
                 DiagnosticSeverity.Error, "jakarta-websocket", "OnMessageDuplicateMethod");
 
         assertJavaDiagnostics(diagnosticsParams, JDT_UTILS, d);

--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.test/src/main/java/org/eclipse/lsp4jakarta/jdt/websocket/JakartaWebSocketTest.java
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.test/src/main/java/org/eclipse/lsp4jakarta/jdt/websocket/JakartaWebSocketTest.java
@@ -98,4 +98,20 @@ public class JakartaWebSocketTest extends BaseJakartaTest {
 
         assertJavaDiagnostics(diagnosticsParams, JDT_UTILS, d);
     }
+
+    @Test
+    public void testDuplicateOnMessage() throws Exception {
+        IJavaProject javaProject = loadJavaProject("jakarta-sample", "");
+        IFile javaFile = javaProject.getProject().getFile(
+                new Path("src/main/java/io/openliberty/sample/jakarta/websocket/DuplicateOnMessage.java"));
+        String uri = javaFile.getLocation().toFile().toURI().toString();
+
+        JakartaDiagnosticsParams diagnosticsParams = new JakartaDiagnosticsParams();
+        diagnosticsParams.setUris(Arrays.asList(uri));
+
+        Diagnostic d = d(17, 66, 70, "Each WebSocket endpoint may only have one message handling method for each of the native WebSocket message formats: text, binary and pong.",
+                DiagnosticSeverity.Error, "jakarta-websocket", "OnMessageDuplicateMethod");
+
+        assertJavaDiagnostics(diagnosticsParams, JDT_UTILS, d);
+    }
 }


### PR DESCRIPTION
Resolves #243

Show diagnostics if a duplicate method is found for a @onMessage method for the same message format (text, binary, or pong).