### PR TITLE
Add ModifyReturnTypeProposal and quick fix for PostConstruct annotated-methods

### DIFF
--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/codeAction/CodeActionHandler.java
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/codeAction/CodeActionHandler.java
@@ -68,6 +68,7 @@ import org.eclipse.lsp4jakarta.jdt.core.persistence.PersistenceConstants;
 import org.eclipse.lsp4jakarta.jdt.core.annotations.AddResourceMissingNameQuickFix;
 import org.eclipse.lsp4jakarta.jdt.core.annotations.AddResourceMissingTypeQuickFix;
 import org.eclipse.lsp4jakarta.jdt.core.annotations.AnnotationConstants;
+import org.eclipse.lsp4jakarta.jdt.core.annotations.PostConstructReturnTypeQuickFix;
 import org.eclipse.lsp4jakarta.jdt.core.annotations.RemovePreDestroyAnnotationQuickFix;
 import org.eclipse.lsp4jakarta.jdt.core.annotations.RemovePostConstructAnnotationQuickFix;
 import org.eclipse.lsp4jakarta.jdt.core.JakartaCorePlugin;
@@ -120,6 +121,7 @@ public class CodeActionHandler {
             ScopeDeclarationQuickFix ScopeDeclarationQuickFix = new ScopeDeclarationQuickFix();
             RemovePreDestroyAnnotationQuickFix RemovePreDestroyAnnotationQuickFix=new RemovePreDestroyAnnotationQuickFix();
             RemovePostConstructAnnotationQuickFix RemovePostConstructAnnotationQuickFix=new RemovePostConstructAnnotationQuickFix();
+            PostConstructReturnTypeQuickFix PostConstructReturnTypeQuickFix = new PostConstructReturnTypeQuickFix();
             RemoveFinalModifierQuickFix RemoveFinalModifierQuickFix = new RemoveFinalModifierQuickFix();
             RemoveStaticModifierQuickFix RemoveStaticModifierQuickFix = new RemoveStaticModifierQuickFix();
             RemoveMethodParametersQuickFix RemoveMethodParametersQuickFix =new RemoveMethodParametersQuickFix();
@@ -146,6 +148,9 @@ public class CodeActionHandler {
                     }
                     if (diagnostic.getCode().getLeft().equals(AnnotationConstants.DIAGNOSTIC_CODE_MISSING_RESOURCE_TYPE_ATTRIBUTE)) {
                         codeActions.addAll(AddResourceMissingTypeQuickFix.getCodeActions(context, diagnostic, monitor));
+                    }
+                    if (diagnostic.getCode().getLeft().equals(AnnotationConstants.DIAGNOSTIC_CODE_POSTCONSTRUCT_RETURN_TYPE)) {
+                        codeActions.addAll(PostConstructReturnTypeQuickFix.getCodeActions(context, diagnostic, monitor));
                     }
                     if (diagnostic.getCode().getLeft().equals(ServletConstants.DIAGNOSTIC_CODE_MISSING_ATTRIBUTE)
                             || diagnostic.getCode().getLeft()

--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/codeAction/proposal/ModifyReturnTypeProposal.java
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/codeAction/proposal/ModifyReturnTypeProposal.java
@@ -1,0 +1,50 @@
+package org.eclipse.lsp4jakarta.jdt.codeAction.proposal;
+
+import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.dom.AST;
+import org.eclipse.jdt.core.dom.ASTNode;
+import org.eclipse.jdt.core.dom.CompilationUnit;
+import org.eclipse.jdt.core.dom.IBinding;
+import org.eclipse.jdt.core.dom.MethodDeclaration;
+import org.eclipse.jdt.core.dom.Type;
+import org.eclipse.jdt.core.dom.rewrite.ASTRewrite;
+import org.eclipse.jdt.internal.core.manipulation.dom.ASTResolving;
+import org.eclipse.lsp4j.CodeActionKind;
+
+public class ModifyReturnTypeProposal extends ChangeCorrectionProposal {
+    
+    private final CompilationUnit invocationNode;
+    private final IBinding binding;
+    private final Type newReturnType;
+
+    public ModifyReturnTypeProposal(String label, ICompilationUnit targetCU, CompilationUnit invocationNode, 
+            IBinding binding, int relevance, Type newReturnType) {
+        super(label, CodeActionKind.QuickFix, targetCU, null, relevance);
+        this.invocationNode = invocationNode;
+        this.binding = binding;
+        this.newReturnType = newReturnType;
+    }
+    
+    @SuppressWarnings("restriction")
+    @Override
+    protected ASTRewrite getRewrite() {
+        ASTNode declNode = null;
+        ASTNode boundNode = invocationNode.findDeclaringNode(binding);
+        CompilationUnit newRoot = invocationNode;
+        
+        if (boundNode != null) {
+            declNode = boundNode;
+        } else {
+            newRoot = ASTResolving.createQuickFixAST(getCompilationUnit(), null);
+            declNode = newRoot.findDeclaringNode(binding.getKey());
+        }
+        
+        if (declNode.getNodeType() == ASTNode.METHOD_DECLARATION) {
+            AST ast = declNode.getAST();
+            ASTRewrite rewrite = ASTRewrite.create(ast);
+            rewrite.set(declNode, MethodDeclaration.RETURN_TYPE2_PROPERTY, newReturnType, null);
+            return rewrite;
+        }
+        return null;
+    }
+}

--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/codeAction/proposal/ModifyReturnTypeProposal.java
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/codeAction/proposal/ModifyReturnTypeProposal.java
@@ -1,3 +1,15 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Yijia Jing
+ *******************************************************************************/
 package org.eclipse.lsp4jakarta.jdt.codeAction.proposal;
 
 import org.eclipse.jdt.core.ICompilationUnit;
@@ -11,12 +23,25 @@ import org.eclipse.jdt.core.dom.rewrite.ASTRewrite;
 import org.eclipse.jdt.internal.core.manipulation.dom.ASTResolving;
 import org.eclipse.lsp4j.CodeActionKind;
 
+/**
+ * Code action proposal for changing the return type of a method.
+ * 
+ * @author Yijia Jing
+ * @see CodeActionHandler
+ * @see PostConstructReturnTypeQuickFix
+ *
+ */
 public class ModifyReturnTypeProposal extends ChangeCorrectionProposal {
     
     private final CompilationUnit invocationNode;
     private final IBinding binding;
     private final Type newReturnType;
 
+    /**
+     * Constructor for ModifyReturnTypeProposal that accepts a return type 
+     * 
+     * @param newReturnType 
+     */
     public ModifyReturnTypeProposal(String label, ICompilationUnit targetCU, CompilationUnit invocationNode, 
             IBinding binding, int relevance, Type newReturnType) {
         super(label, CodeActionKind.QuickFix, targetCU, null, relevance);

--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/codeAction/proposal/ModifyReturnTypeProposal.java
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/codeAction/proposal/ModifyReturnTypeProposal.java
@@ -38,9 +38,9 @@ public class ModifyReturnTypeProposal extends ChangeCorrectionProposal {
     private final Type newReturnType;
 
     /**
-     * Constructor for ModifyReturnTypeProposal that accepts a return type 
+     * Constructor for ModifyReturnTypeProposal that accepts the new return type of a method.
      * 
-     * @param newReturnType 
+     * @param newReturnType the new return type to change to
      */
     public ModifyReturnTypeProposal(String label, ICompilationUnit targetCU, CompilationUnit invocationNode, 
             IBinding binding, int relevance, Type newReturnType) {

--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/core/annotations/PostConstructReturnTypeQuickFix.java
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/core/annotations/PostConstructReturnTypeQuickFix.java
@@ -1,3 +1,15 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Yijia Jing
+ *******************************************************************************/
 package org.eclipse.lsp4jakarta.jdt.core.annotations;
 
 import java.util.ArrayList;
@@ -17,22 +29,26 @@ import org.eclipse.lsp4jakarta.jdt.codeAction.JavaCodeActionContext;
 import org.eclipse.lsp4jakarta.jdt.codeAction.proposal.ChangeCorrectionProposal;
 import org.eclipse.lsp4jakarta.jdt.codeAction.proposal.ModifyReturnTypeProposal;
 
+/**
+ * Quick fix for AnnotationDiagnosticsCollector that changes the return type of a method to void.
+ * Uses ModifyReturnTypeProposal.
+ * 
+ * @author Yijia Jing
+ *
+ */
 public class PostConstructReturnTypeQuickFix implements IJavaCodeActionParticipant {
 
     @Override
     public List<? extends CodeAction> getCodeActions(JavaCodeActionContext context, Diagnostic diagnostic,
             IProgressMonitor monitor) throws CoreException {
         List<CodeAction> codeActions = new ArrayList<>();
-
         ASTNode node = context.getCoveredNode();
         IBinding parentType = getBinding(node);
-        String msg = "Change return type to void";
-        ChangeCorrectionProposal proposal = new ModifyReturnTypeProposal(msg, context.getCompilationUnit(),
+        String name = "Change return type to void";
+        ChangeCorrectionProposal proposal = new ModifyReturnTypeProposal(name, context.getCompilationUnit(),
                 context.getASTRoot(), parentType, 0, node.getAST().newPrimitiveType(PrimitiveType.VOID));
         CodeAction codeAction = context.convertToCodeAction(proposal, diagnostic);
-        if (codeAction != null) {
-            codeActions.add(codeAction);
-        }
+        codeActions.add(codeAction);
         return codeActions;
     }
 

--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/core/annotations/PostConstructReturnTypeQuickFix.java
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/core/annotations/PostConstructReturnTypeQuickFix.java
@@ -1,0 +1,45 @@
+package org.eclipse.lsp4jakarta.jdt.core.annotations;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.jdt.core.dom.ASTNode;
+import org.eclipse.jdt.core.dom.IBinding;
+import org.eclipse.jdt.core.dom.MethodDeclaration;
+import org.eclipse.jdt.core.dom.PrimitiveType;
+import org.eclipse.lsp4j.CodeAction;
+import org.eclipse.lsp4j.Diagnostic;
+import org.eclipse.jdt.internal.corext.dom.Bindings;
+import org.eclipse.lsp4jakarta.jdt.codeAction.IJavaCodeActionParticipant;
+import org.eclipse.lsp4jakarta.jdt.codeAction.JavaCodeActionContext;
+import org.eclipse.lsp4jakarta.jdt.codeAction.proposal.ChangeCorrectionProposal;
+import org.eclipse.lsp4jakarta.jdt.codeAction.proposal.ModifyReturnTypeProposal;
+
+public class PostConstructReturnTypeQuickFix implements IJavaCodeActionParticipant {
+
+    @Override
+    public List<? extends CodeAction> getCodeActions(JavaCodeActionContext context, Diagnostic diagnostic,
+            IProgressMonitor monitor) throws CoreException {
+        List<CodeAction> codeActions = new ArrayList<>();
+
+        ASTNode node = context.getCoveredNode();
+        IBinding parentType = getBinding(node);
+        String msg = "Change return type to void";
+        ChangeCorrectionProposal proposal = new ModifyReturnTypeProposal(msg, context.getCompilationUnit(),
+                context.getASTRoot(), parentType, 0, node.getAST().newPrimitiveType(PrimitiveType.VOID));
+        CodeAction codeAction = context.convertToCodeAction(proposal, diagnostic);
+        if (codeAction != null) {
+            codeActions.add(codeAction);
+        }
+        return codeActions;
+    }
+
+    protected IBinding getBinding(ASTNode node) {
+        if (node.getParent() instanceof MethodDeclaration) {
+            return ((MethodDeclaration) node.getParent()).resolveBinding();
+        }
+        return Bindings.getBindingOfParentType(node);
+    }
+}

--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.test/projects/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/annotations/PostConstructAnnotation.java
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.test/projects/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/annotations/PostConstructAnnotation.java
@@ -7,28 +7,26 @@ import jakarta.annotation.Resource;
 public class GraduatingStudent {
 
     private Integer studentId;
-	
+
     private boolean isHappy;
 
     private boolean isSad;
-	
-	@PostConstruct()
-	public Integer getStudentId() {
-		return this.studentId;
-	}
-	
-	@PostConstruct
-	public void getHappiness(String type) {
-		
-	}
-	
-	@PostConstruct
-	public void throwTantrum() throws Exception {
-		System.out.println("I'm sad");
-	}
 
+    @PostConstruct()
+    public Integer getStudentId() {
+        return this.studentId;
+    }
+
+    @PostConstruct
+    public void getHappiness(String type) {
+
+    }
+
+    @PostConstruct
+    public void throwTantrum() throws Exception {
+        System.out.println("I'm sad");
+    }
 
     private String emailAddress;
-
 
 }

--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.test/src/main/java/org/eclipse/lsp4jakarta/jdt/annotations/PostConstructAnnotationTest.java
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.test/src/main/java/org/eclipse/lsp4jakarta/jdt/annotations/PostConstructAnnotationTest.java
@@ -36,38 +36,42 @@ import org.junit.Test;
 
 public class PostConstructAnnotationTest extends BaseJakartaTest {
 
-	protected static JDTUtils JDT_UTILS = new JDTUtils();
+    protected static JDTUtils JDT_UTILS = new JDTUtils();
 
-	@Test
-	public void GeneratedAnnotation() throws Exception {
-		IJavaProject javaProject = loadJavaProject("jakarta-sample", "");
-		IFile javaFile = javaProject.getProject().getFile(
-				new Path("src/main/java/io/openliberty/sample/jakarta/annotations/PostConstructAnnotation.java"));
-		String uri = javaFile.getLocation().toFile().toURI().toString();
+    @Test
+    public void GeneratedAnnotation() throws Exception {
+        IJavaProject javaProject = loadJavaProject("jakarta-sample", "");
+        IFile javaFile = javaProject.getProject().getFile(
+                new Path("src/main/java/io/openliberty/sample/jakarta/annotations/PostConstructAnnotation.java"));
+        String uri = javaFile.getLocation().toFile().toURI().toString();
 
-		JakartaDiagnosticsParams diagnosticsParams = new JakartaDiagnosticsParams();
-		diagnosticsParams.setUris(Arrays.asList(uri));
+        JakartaDiagnosticsParams diagnosticsParams = new JakartaDiagnosticsParams();
+        diagnosticsParams.setUris(Arrays.asList(uri));
 
-		// expected Diagnostics
+        // expected Diagnostics
 
-		Diagnostic d1 = d(15, 16, 28, "A method with the annotation @PostConstruct must be void.",
-				DiagnosticSeverity.Error, "jakarta-annotations", "PostConstructReturnType");
+        Diagnostic d1 = d(15, 19, 31, "A method with the annotation @PostConstruct must be void.",
+                DiagnosticSeverity.Error, "jakarta-annotations", "PostConstructReturnType");
 
-		Diagnostic d2 = d(20, 13, 25, "A method with the annotation @PostConstruct must not have any parameters.",
-				DiagnosticSeverity.Error, "jakarta-annotations", "PostConstructParams");
+        Diagnostic d2 = d(20, 16, 28, "A method with the annotation @PostConstruct must not have any parameters.",
+                DiagnosticSeverity.Error, "jakarta-annotations", "PostConstructParams");
 
-		Diagnostic d3 = d(25, 13, 25, "A method with the annotation @PostConstruct must not throw checked exceptions.",
-				DiagnosticSeverity.Warning, "jakarta-annotations", "PostConstructException");
+        Diagnostic d3 = d(25, 16, 28, "A method with the annotation @PostConstruct must not throw checked exceptions.",
+                DiagnosticSeverity.Warning, "jakarta-annotations", "PostConstructException");
 
-		assertJavaDiagnostics(diagnosticsParams, JDT_UTILS, d1, d2, d3);
+        assertJavaDiagnostics(diagnosticsParams, JDT_UTILS, d1, d2, d3);
 
-		JakartaJavaCodeActionParams codeActionParams = createCodeActionParams(uri, d2);
-		TextEdit te = te(19, 1, 20, 1, "");
-		TextEdit te1 = te(20, 26, 20, 37, "");
-		CodeAction ca = ca(uri, "Remove @PostConstruct", d2, te);
-		CodeAction ca1 = ca(uri, "Remove all parameters", d2, te1);
-		assertJavaCodeAction(codeActionParams, JDT_UTILS, ca, ca1);
-
-	}
+        JakartaJavaCodeActionParams codeActionParams1 = createCodeActionParams(uri, d2);
+        TextEdit te1 = te(19, 4, 20, 4, "");
+        TextEdit te2 = te(20, 29, 20, 40, "");
+        CodeAction ca1 = ca(uri, "Remove @PostConstruct", d2, te1);
+        CodeAction ca2 = ca(uri, "Remove all parameters", d2, te2);
+        assertJavaCodeAction(codeActionParams1, JDT_UTILS, ca1, ca2);
+        
+        JakartaJavaCodeActionParams codeActionParams2 = createCodeActionParams(uri, d1);
+        TextEdit te3 = te(15, 11, 15, 18, "void");
+        CodeAction ca3 = ca(uri, "Change return type to void", d1, te3);
+        assertJavaCodeAction(codeActionParams2, JDT_UTILS, ca3);
+    }
 
 }


### PR DESCRIPTION
Resolves #227. Also resolves the second part of #183 (the quick fix "change return type to void" for the PostConstruct diagnostic).

Add a proposal that modifies the return type of a method. A quick fix on the return type of PostConstruct annotated-methods is also added using this proposal.