### PR TITLE
Check the return of getMatchedJavaElementName for null.

### DIFF
--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/core/cdi/ManagedBeanDiagnosticsCollector.java
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/core/cdi/ManagedBeanDiagnosticsCollector.java
@@ -314,10 +314,10 @@ public class ManagedBeanDiagnosticsCollector extends AbstractDiagnosticsCollecto
                             for (IAnnotation annotation : annotations) {
                                 String matchedAnnotation = getMatchedJavaElementName(type, annotation.getElementName(),
                                         INVALID_INJECT_PARAMS_FQ);
-                                if (matchedAnnotation.equals(DISPOSES_FQ_NAME)) {
+                                if (DISPOSES_FQ_NAME.equals(matchedAnnotation)) {
                                     numDisposes++;
-                                } else if (matchedAnnotation.equals(OBSERVES_FQ_NAME)
-                                        || matchedAnnotation.equals(OBSERVES_ASYNC_FQ_NAME)) {
+                                } else if (OBSERVES_FQ_NAME.equals(matchedAnnotation)
+                                        || OBSERVES_ASYNC_FQ_NAME.equals(matchedAnnotation)) {
                                     invalidAnnotations.add("@" + annotation.getElementName());
                                 }
                             }


### PR DESCRIPTION
Signed-off-by: Paul Gooderham <turkeyonmarblerye@gmail.com>
Fixes #359 
@kathrynkodama  @bensonnw  please review this fix. Originally found in the IntelliJ code.