### PR TITLE
Change class JDTServicesManager to PropertiesManagerForJava

### DIFF
--- a/jakarta.eclipse/org.eclipse.lsp4jakarta.lsp4e.core/src/org/eclipse/lsp4jakarta/lsp4e/JakartaLanguageClient.java
+++ b/jakarta.eclipse/org.eclipse.lsp4jakarta.lsp4e.core/src/org/eclipse/lsp4jakarta/lsp4e/JakartaLanguageClient.java
@@ -30,7 +30,7 @@ import org.eclipse.lsp4jakarta.api.JakartaLanguageClientAPI;
 import org.eclipse.lsp4jakarta.commons.JakartaClasspathParams;
 import org.eclipse.lsp4jakarta.commons.JakartaDiagnosticsParams;
 import org.eclipse.lsp4jakarta.commons.JakartaJavaCodeActionParams;
-import org.eclipse.lsp4jakarta.jdt.core.JDTServicesManager;
+import org.eclipse.lsp4jakarta.jdt.core.PropertiesManagerForJava;
 import org.eclipse.lsp4jakarta.jdt.core.JDTUtils;
 
 public class JakartaLanguageClient extends LanguageClientImpl implements JakartaLanguageClientAPI {
@@ -56,7 +56,7 @@ public class JakartaLanguageClient extends LanguageClientImpl implements Jakarta
             IProgressMonitor monitor = getProgressMonitor(cancelChecker);
 
             List<PublishDiagnosticsParams> publishDiagnostics = new ArrayList<PublishDiagnosticsParams>();
-            publishDiagnostics = JDTServicesManager.getInstance().getJavaDiagnostics(jakartaParams.getUris(), monitor);
+            publishDiagnostics = PropertiesManagerForJava.getInstance().getJavaDiagnostics(jakartaParams.getUris(), monitor);
             return publishDiagnostics;
         });
     }
@@ -64,7 +64,7 @@ public class JakartaLanguageClient extends LanguageClientImpl implements Jakarta
     @Override
     public CompletableFuture<List<String>> getContextBasedFilter(JakartaClasspathParams classpathParams) {
         return CompletableFutures.computeAsync((cancelChecker) -> {
-            return JDTServicesManager.getInstance().getExistingContextsFromClassPath(classpathParams.getUri(),
+            return PropertiesManagerForJava.getInstance().getExistingContextsFromClassPath(classpathParams.getUri(),
                     classpathParams.getSnippetCtx());
         });
     }
@@ -75,7 +75,7 @@ public class JakartaLanguageClient extends LanguageClientImpl implements Jakarta
         return CompletableFutures.computeAsync((cancelChecker) -> {
             IProgressMonitor monitor = getProgressMonitor(cancelChecker);
             try {
-                return (List<CodeAction>) JDTServicesManager.getInstance().getCodeAction(params, utils, monitor);
+                return (List<CodeAction>) PropertiesManagerForJava.getInstance().getCodeAction(params, utils, monitor);
             } catch (JavaModelException e) {
                 return null;
             }

--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/core/PropertiesManagerForJava.java
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/core/PropertiesManagerForJava.java
@@ -54,19 +54,19 @@ import org.eclipse.lsp4jakarta.jdt.core.websocket.WebSocketDiagnosticsCollector;
  * Server
  * 
  */
-public class JDTServicesManager {
+public class PropertiesManagerForJava {
 
     private List<DiagnosticsCollector> diagnosticsCollectors = new ArrayList<>();
 
-    private static final JDTServicesManager INSTANCE = new JDTServicesManager();
+    private static final PropertiesManagerForJava INSTANCE = new PropertiesManagerForJava();
 
     private final CodeActionHandler codeActionHandler;
 
-    public static JDTServicesManager getInstance() {
+    public static PropertiesManagerForJava getInstance() {
         return INSTANCE;
     }
 
-    private JDTServicesManager() {
+    private PropertiesManagerForJava() {
         diagnosticsCollectors.add(new ServletDiagnosticsCollector());
         diagnosticsCollectors.add(new AnnotationDiagnosticsCollector());
         diagnosticsCollectors.add(new FilterDiagnosticsCollector());

--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/internal/core/ls/JakartaDelegateCommandHandlerForJava.java
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/internal/core/ls/JakartaDelegateCommandHandlerForJava.java
@@ -28,7 +28,7 @@ import org.eclipse.lsp4j.Range;
 import org.eclipse.lsp4j.TextDocumentIdentifier;
 import org.eclipse.lsp4j.jsonrpc.CompletableFutures;
 import org.eclipse.lsp4jakarta.commons.JakartaJavaCodeActionParams;
-import org.eclipse.lsp4jakarta.jdt.core.JDTServicesManager;
+import org.eclipse.lsp4jakarta.jdt.core.PropertiesManagerForJava;
 import org.eclipse.lsp4jakarta.jdt.core.JDTUtils;
 
 /**
@@ -77,7 +77,7 @@ public class JakartaDelegateCommandHandlerForJava implements IDelegateCommandHan
         String uri = ArgumentUtils.getString(obj, "uri");
         List<String> snippetCtx = ArgumentUtils.getStringList(obj, "snippetCtx");
         return CompletableFutures.computeAsync((cancelChecker) -> {
-            return JDTServicesManager.getInstance().getExistingContextsFromClassPath(uri, snippetCtx);
+            return PropertiesManagerForJava.getInstance().getExistingContextsFromClassPath(uri, snippetCtx);
         });
     }
 
@@ -100,7 +100,7 @@ public class JakartaDelegateCommandHandlerForJava implements IDelegateCommandHan
         List<String> uri = ArgumentUtils.getStringList(obj, "uris");
         return CompletableFutures.computeAsync((cancelChecker) -> {
             List<PublishDiagnosticsParams> publishDiagnostics = new ArrayList<PublishDiagnosticsParams>();
-            publishDiagnostics = JDTServicesManager.getInstance().getJavaDiagnostics(uri, monitor);
+            publishDiagnostics = PropertiesManagerForJava.getInstance().getJavaDiagnostics(uri, monitor);
             return publishDiagnostics;
         });
     }
@@ -140,7 +140,7 @@ public class JakartaDelegateCommandHandlerForJava implements IDelegateCommandHan
         return CompletableFutures.computeAsync((cancelChecker) -> {
             List<CodeAction> codeActions = new ArrayList<CodeAction>();
             try {
-                codeActions = JDTServicesManager.getInstance().getCodeAction(params, utils, monitor);
+                codeActions = PropertiesManagerForJava.getInstance().getCodeAction(params, utils, monitor);
             } catch (JavaModelException e) {
                 // TODO Auto-generated catch block
                 JavaLanguageServerPlugin

--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.test/src/main/java/org/eclipse/lsp4jakarta/jdt/core/JakartaForJavaAssert.java
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.test/src/main/java/org/eclipse/lsp4jakarta/jdt/core/JakartaForJavaAssert.java
@@ -61,7 +61,7 @@ public class JakartaForJavaAssert {
 
     public static void assertJavaCodeAction(JakartaJavaCodeActionParams params, JDTUtils utils, CodeAction... expected)
             throws JavaModelException {
-        List<? extends CodeAction> actual = JDTServicesManager.getInstance().getCodeAction(params, utils,
+        List<? extends CodeAction> actual = PropertiesManagerForJava.getInstance().getCodeAction(params, utils,
                 new NullProgressMonitor());
         assertCodeActions(actual != null && actual.size() > 0 ? actual : Collections.emptyList(), expected);
     }
@@ -159,7 +159,7 @@ public class JakartaForJavaAssert {
 
     public static void assertJavaDiagnostics(JakartaDiagnosticsParams params, JDTUtils utils, Diagnostic... expected)
             throws JavaModelException {
-        List<PublishDiagnosticsParams> actual = JDTServicesManager.getInstance().getJavaDiagnostics(params);
+        List<PublishDiagnosticsParams> actual = PropertiesManagerForJava.getInstance().getJavaDiagnostics(params);
 
         assertDiagnostics(
                 actual != null && actual.size() > 0 ? actual.get(0).getDiagnostics() : Collections.emptyList(),


### PR DESCRIPTION
In issue https://github.com/OpenLiberty/liberty-tools-intellij/issues/191 we see a problem identifying changes related to the language server component versus the Java analysis (JDT) component. When JDTServicesManager was created it was a version of a class called PropertiesManagerForJava. With this pull request we restore that name and make it similar to the naming convention in other language server projects. This should make it easier to port changes from one project to another. 

Signed-off-by: Paul Gooderham <turkeyonmarblerye@gmail.com>