### PR TITLE
Upgrade assembly-plugin in jakarta.ls

### DIFF
--- a/jakarta.ls/pom.xml
+++ b/jakarta.ls/pom.xml
@@ -110,6 +110,7 @@
     <plugins>
       <plugin>
         <artifactId>maven-assembly-plugin</artifactId>
+        <version>3.5.0</version>
         <executions>
           <execution>
             <id>make-assembly</id>


### PR DESCRIPTION
This version includes the Maven descriptor of the artifact itself, i.e.
> META-INF/maven/org.eclipse.lsp4jakarta/org.eclipse.lsp4jakarta.ls/pom.xml
> META-INF/maven/org.eclipse.lsp4jakarta/org.eclipse.lsp4jakarta.ls/pom.properties

Also it is less verbose, and so quicker.