### PR TITLE
Ensure getCodeActions() always returns a list and not null.

### DIFF
--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/codeAction/proposal/RemoveMultipleAnnotations.java
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/codeAction/proposal/RemoveMultipleAnnotations.java
@@ -46,6 +46,7 @@ public abstract class RemoveMultipleAnnotations extends RemoveAnnotationConflict
     @Override
     public List<? extends CodeAction> getCodeActions(JavaCodeActionContext context, Diagnostic diagnostic,
             IProgressMonitor monitor) throws CoreException {
+        List<CodeAction> codeActions = new ArrayList<>();
         ASTNode node = context.getCoveredNode();
         IBinding parentType = getBinding(node);
 
@@ -55,16 +56,14 @@ public abstract class RemoveMultipleAnnotations extends RemoveAnnotationConflict
                 .mapToObj(idx -> diagnosticData.get(idx).getAsString()).collect(Collectors.toList());
 
         if (parentType != null) {
-            List<CodeAction> codeActions = new ArrayList<>();
             
             List<List<String>> annotationsListsToRemove = getMultipleRemoveAnnotations(annotations);
             for (List<String> annotationList : annotationsListsToRemove) {
                 String[] annotationsToRemove = annotationList.toArray(new String[annotationList.size()]);
                 removeAnnotation(diagnostic, context, parentType, codeActions, annotationsToRemove);
             }
-            return codeActions;
         }
-        return null;
+        return codeActions;
     }
     
     /**

--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/codeAction/proposal/quickfix/InsertAnnotationMissingQuickFix.java
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/codeAction/proposal/quickfix/InsertAnnotationMissingQuickFix.java
@@ -72,14 +72,13 @@ public class InsertAnnotationMissingQuickFix implements IJavaCodeActionParticipa
     @Override
     public List<? extends CodeAction> getCodeActions(JavaCodeActionContext context, Diagnostic diagnostic,
             IProgressMonitor monitor) throws CoreException {
+        List<CodeAction> codeActions = new ArrayList<>();
         ASTNode node = context.getCoveredNode();
         IBinding parentType = getBinding(node);
         if (parentType != null) {
-            List<CodeAction> codeActions = new ArrayList<>();
             insertAnnotations(diagnostic, context, parentType, codeActions);
-            return codeActions;
         }
-        return null;
+        return codeActions;
     }
 
     protected static IBinding getBinding(ASTNode node) {

--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/codeAction/proposal/quickfix/RemoveAnnotationConflictQuickFix.java
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/codeAction/proposal/quickfix/RemoveAnnotationConflictQuickFix.java
@@ -71,15 +71,13 @@ public class RemoveAnnotationConflictQuickFix implements IJavaCodeActionParticip
     @Override
     public List<? extends CodeAction> getCodeActions(JavaCodeActionContext context, Diagnostic diagnostic,
             IProgressMonitor monitor) throws CoreException {
+        List<CodeAction> codeActions = new ArrayList<>();
         ASTNode node = context.getCoveredNode();
         IBinding parentType = getBinding(node);
         if (parentType != null) {
-            List<CodeAction> codeActions = new ArrayList<>();
             removeAnnotations(diagnostic, context, parentType, codeActions);
-            return codeActions;
         }
-        return null;
-
+        return codeActions;
     }
 
     protected void removeAnnotations(Diagnostic diagnostic, JavaCodeActionContext context, IBinding parentType,

--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/core/cdi/ManagedBeanNoArgConstructorQuickFix.java
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/core/cdi/ManagedBeanNoArgConstructorQuickFix.java
@@ -44,17 +44,13 @@ public class ManagedBeanNoArgConstructorQuickFix  implements IJavaCodeActionPart
     @Override
     public List<? extends CodeAction> getCodeActions(JavaCodeActionContext context, Diagnostic diagnostic,
             IProgressMonitor monitor) throws CoreException {
+        List<CodeAction> codeActions = new ArrayList<>();
         ASTNode node = context.getCoveredNode();
         IBinding parentType = getBinding(node);
         if (parentType != null) {
-            List<CodeAction> codeActions = new ArrayList<>();
-            
             codeActions.addAll(addConstructor(diagnostic, context, parentType));
-           
-
-            return codeActions;
         }
-        return null;
+        return codeActions;
     }
     
     protected static IBinding getBinding(ASTNode node) {

--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/core/cdi/ScopeDeclarationQuickFix.java
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/core/cdi/ScopeDeclarationQuickFix.java
@@ -38,6 +38,7 @@ public class ScopeDeclarationQuickFix extends RemoveAnnotationConflictQuickFix {
     @Override
     public List<? extends CodeAction> getCodeActions(JavaCodeActionContext context, Diagnostic diagnostic,
             IProgressMonitor monitor) throws CoreException {
+        List<CodeAction> codeActions = new ArrayList<>();
         ASTNode node = context.getCoveredNode();
         IBinding parentType = getBinding(node);
 
@@ -49,7 +50,6 @@ public class ScopeDeclarationQuickFix extends RemoveAnnotationConflictQuickFix {
         annotations.remove(ManagedBeanConstants.PRODUCES);
 
         if (parentType != null) {
-            List<CodeAction> codeActions = new ArrayList<>();
             /**
              * for each annotation, choose the current annotation to keep and remove the
              * rest since we can have at most one scope annotation.
@@ -62,9 +62,8 @@ public class ScopeDeclarationQuickFix extends RemoveAnnotationConflictQuickFix {
                         resultingAnnotations.toArray(new String[] {}));
             }
 
-            return codeActions;
         }
-        return null;
+        return codeActions;
 
     }
 }

--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/core/jax_rs/NoResourcePublicConstructorQuickFix.java
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/core/jax_rs/NoResourcePublicConstructorQuickFix.java
@@ -47,13 +47,13 @@ public class NoResourcePublicConstructorQuickFix implements IJavaCodeActionParti
     @Override
     public List<? extends CodeAction> getCodeActions(JavaCodeActionContext context, Diagnostic diagnostic,
             IProgressMonitor monitor) throws CoreException {
+        List<CodeAction> codeActions = new ArrayList<>();
         ASTNode node = context.getCoveredNode();
         MethodDeclaration parentNode = (MethodDeclaration) node.getParent();
         IMethodBinding parentMethod = parentNode.resolveBinding();
         IBinding parentType = getBinding(node);
         
         if (parentMethod != null) {
-            List<CodeAction> codeActions = new ArrayList<>();
 
             final String TITLE_MESSAGE = "Make constructor public";
 
@@ -72,9 +72,8 @@ public class NoResourcePublicConstructorQuickFix implements IJavaCodeActionParti
             codeAction = context.convertToCodeAction(proposal, diagnostic);
             codeActions.add(codeAction);
             
-            return codeActions;
         }
-        return null;
+        return codeActions;
     }
 
     protected static IBinding getBinding(ASTNode node) {

--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/core/jax_rs/NonPublicResourceMethodQuickFix.java
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/core/jax_rs/NonPublicResourceMethodQuickFix.java
@@ -41,12 +41,12 @@ public class NonPublicResourceMethodQuickFix implements IJavaCodeActionParticipa
     @Override
     public List<? extends CodeAction> getCodeActions(JavaCodeActionContext context, Diagnostic diagnostic,
             IProgressMonitor monitor) throws CoreException {
+        List<CodeAction> codeActions = new ArrayList<>();
         ASTNode node = context.getCoveredNode();
         MethodDeclaration parentNode = (MethodDeclaration) node.getParent();
         IMethodBinding parentMethod = parentNode.resolveBinding();
 
         if (parentMethod != null) {
-            List<CodeAction> codeActions = new ArrayList<>();
 
             final String TITLE_MESSAGE = "Make method public";
 
@@ -57,9 +57,8 @@ public class NonPublicResourceMethodQuickFix implements IJavaCodeActionParticipa
             CodeAction codeAction = context.convertToCodeAction(proposal, diagnostic);
             codeAction.setTitle(TITLE_MESSAGE);
             codeActions.add(codeAction);
-            return codeActions;
         }
-        return null;
+        return codeActions;
     }
 
 }

--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/core/jax_rs/ResourceMethodMultipleEntityParamsQuickFix.java
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/core/jax_rs/ResourceMethodMultipleEntityParamsQuickFix.java
@@ -45,12 +45,12 @@ public class ResourceMethodMultipleEntityParamsQuickFix implements IJavaCodeActi
     @Override
     public List<? extends CodeAction> getCodeActions(JavaCodeActionContext context, Diagnostic diagnostic,
             IProgressMonitor monitor) throws CoreException {
+        List<CodeAction> codeActions = new ArrayList<>();
         ASTNode node = context.getCoveredNode();
         MethodDeclaration parentNode = (MethodDeclaration) node.getParent();
         IMethodBinding parentMethod = parentNode.resolveBinding();
 
         if (parentMethod != null) {
-            List<CodeAction> codeActions = new ArrayList<>();
 
             List<SingleVariableDeclaration> params = (List<SingleVariableDeclaration>) parentNode.parameters();
 
@@ -76,9 +76,8 @@ public class ResourceMethodMultipleEntityParamsQuickFix implements IJavaCodeActi
                 codeActions.add(codeAction);
             }
 
-            return codeActions;
         }
-        return null;
+        return codeActions;
     }
 
     /**

--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/core/persistence/PersistenceEntityQuickFix.java
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/core/persistence/PersistenceEntityQuickFix.java
@@ -64,19 +64,17 @@ public class PersistenceEntityQuickFix implements IJavaCodeActionParticipant {
     @Override
     public List<? extends CodeAction> getCodeActions(JavaCodeActionContext context, Diagnostic diagnostic,
             IProgressMonitor monitor) throws CoreException {
+        List<CodeAction> codeActions = new ArrayList<>();
         ASTNode node = context.getCoveredNode();
         IBinding parentType = getBinding(node);
         if (parentType != null) {
-            List<CodeAction> codeActions = new ArrayList<>();
             
             // add constructor
             if (diagnostic.getCode().getLeft().equals(PersistenceConstants.DIAGNOSTIC_CODE_MISSING_EMPTY_CONSTRUCTOR)) {
                 codeActions.addAll(addConstructor(diagnostic, context, parentType));
             }
-            
-            return codeActions;
         }
-        return null;
+        return codeActions;
     }
     
     protected static IBinding getBinding(ASTNode node) {

--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/core/servlet/FilterImplementationQuickFix.java
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/core/servlet/FilterImplementationQuickFix.java
@@ -45,10 +45,10 @@ public class FilterImplementationQuickFix implements IJavaCodeActionParticipant 
     @Override
     public List<? extends CodeAction> getCodeActions(JavaCodeActionContext context, Diagnostic diagnostic,
             IProgressMonitor monitor) throws CoreException {
+        List<CodeAction> codeActions = new ArrayList<>();
         ASTNode node = context.getCoveredNode();
         ITypeBinding parentType = Bindings.getBindingOfParentType(node);
         if (parentType != null) {
-            List<CodeAction> codeActions = new ArrayList<>();
             // Create code action
             // interface
             final String TITLE_MESSAGE = "Let ''{0}'' implement ''{1}''";
@@ -60,8 +60,7 @@ public class FilterImplementationQuickFix implements IJavaCodeActionParticipant 
             CodeAction codeAction = context.convertToCodeAction(proposal, diagnostic);
             codeAction.setTitle(MessageFormat.format(TITLE_MESSAGE, args));
             codeActions.add(codeAction);
-            return codeActions;
         }
-        return null;
+        return codeActions;
     }
 }

--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/core/servlet/HttpServletQuickFix.java
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/core/servlet/HttpServletQuickFix.java
@@ -45,10 +45,10 @@ public class HttpServletQuickFix implements IJavaCodeActionParticipant {
     @Override
     public List<? extends CodeAction> getCodeActions(JavaCodeActionContext context, Diagnostic diagnostic,
             IProgressMonitor monitor) throws CoreException {
+        List<CodeAction> codeActions = new ArrayList<>();
         ASTNode node = context.getCoveredNode();
         ITypeBinding parentType = Bindings.getBindingOfParentType(node);
         if (parentType != null) {
-            List<CodeAction> codeActions = new ArrayList<>();
             // Create code action
             // interface
             final String TITLE_MESSAGE = "Let ''{0}'' extend ''{1}''";
@@ -60,8 +60,7 @@ public class HttpServletQuickFix implements IJavaCodeActionParticipant {
             CodeAction codeAction = context.convertToCodeAction(proposal, diagnostic);
             codeAction.setTitle(MessageFormat.format(TITLE_MESSAGE, args));
             codeActions.add(codeAction);
-            return codeActions;
         }
-        return null;
+        return codeActions;
     }
 }

--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/core/servlet/ListenerImplementationQuickFix.java
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/core/servlet/ListenerImplementationQuickFix.java
@@ -45,10 +45,10 @@ public class ListenerImplementationQuickFix implements IJavaCodeActionParticipan
     @Override
     public List<? extends CodeAction> getCodeActions(JavaCodeActionContext context, Diagnostic diagnostic,
             IProgressMonitor monitor) throws CoreException {
+        List<CodeAction> codeActions = new ArrayList<>();
         ASTNode node = context.getCoveredNode();
         ITypeBinding parentType = Bindings.getBindingOfParentType(node);
         if (parentType != null) {
-            List<CodeAction> codeActions = new ArrayList<>();
             // Create code action
             // interface
 
@@ -77,9 +77,8 @@ public class ListenerImplementationQuickFix implements IJavaCodeActionParticipan
             codeActions.add(ca4);
             codeActions.add(ca5);
             codeActions.add(ca6);
-            return codeActions;
         }
-        return null;
+        return codeActions;
     }
 
     private CodeAction setUpCodeAction(ITypeBinding parentType, Diagnostic diagnostic, JavaCodeActionContext context,


### PR DESCRIPTION
Fixes #449

Fixes the exception `Cannot invoke "java.util.Collection.toArray()" because "<parameter1>" is null`

In each case we run code like:
`codeActions.addAll(AddPathParamQuickFix.getCodeActions(context, diagnostic, monitor));`
and null is not a valid arg to `addAll()`. This usually does not happen because usually the program is well formed and if the diagnostic can be detected then a quick fix can be created. However in some cases syntax errors are too severe and the quick fix creation fails and a null may be returned. 