### PR TITLE
Update liberty-maven-plugin config in test projects for latest version

### DIFF
--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.test/projects/demo-servlet-no-diagnostics/pom.xml
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.test/projects/demo-servlet-no-diagnostics/pom.xml
@@ -85,15 +85,7 @@
             <plugin>
                 <groupId>io.openliberty.tools</groupId>
                 <artifactId>liberty-maven-plugin</artifactId>
-                <version>3.3.4</version>
-                <configuration>
-                    <runtimeArtifact>
-                        <groupId>io.openliberty.beta</groupId>
-                        <artifactId>openliberty-jakartaee9</artifactId>
-                        <version>21.0.0.2-beta</version>
-                        <type>zip</type>
-                    </runtimeArtifact>
-                </configuration>
+                <version>3.8.2</version>
             </plugin>
             <!-- end::libertyMavenPlugin[] -->
             <plugin>

--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.test/projects/jakarta-sample/pom.xml
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.test/projects/jakarta-sample/pom.xml
@@ -82,15 +82,7 @@
             <plugin>
                 <groupId>io.openliberty.tools</groupId>
                 <artifactId>liberty-maven-plugin</artifactId>
-                <version>3.3.4</version>
-                <configuration>
-                    <runtimeArtifact>
-                        <groupId>io.openliberty</groupId>
-                        <artifactId>openliberty-jakartaee9</artifactId>
-                        <version>21.0.0.2</version>
-                        <type>zip</type>
-                    </runtimeArtifact>
-                </configuration>
+                <version>3.8.2</version>
             </plugin>
             <!-- end::libertyMavenPlugin[] -->
             <plugin>

--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.test/projects/jakarta-sample/src/main/liberty/config/server.xml
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.test/projects/jakarta-sample/src/main/liberty/config/server.xml
@@ -1,6 +1,6 @@
 <server description="Sample Liberty server">
     <featureManager>
-        <feature>jakartaee-9.0</feature>
+        <feature>jakartaee-9.1</feature>
     </featureManager>
 
     <webApplication location="${artifactId}.war" contextRoot="/" />


### PR DESCRIPTION
Don't need to use the beta Open Liberty with the newest Liberty versions that will be installed by default.  Also update to latest liberty-maven-plugin version.