### PR TITLE
Fix package name in snippets for vscode

### DIFF
--- a/jakarta.eclipse/org.eclipse.lsp4jakarta.lsp4e.core/src/main/java/org/eclipse/lsp4jakarta/lsp4e/JakartaLSConnection.java
+++ b/jakarta.eclipse/org.eclipse.lsp4jakarta.lsp4e.core/src/main/java/org/eclipse/lsp4jakarta/lsp4e/JakartaLSConnection.java
@@ -49,8 +49,8 @@ public class JakartaLSConnection extends ProcessStreamConnectionProvider {
 
         String debugPortString = System.getProperty(getClass().getName() + ".debugPort");
         if (debugPortString != null) {
-            commands.add("-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address="
-                         + debugPortString);
+            //commands.add("-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address="
+            //             + debugPortString);
         }
 
         commands.add("-classpath");

--- a/jakarta.eclipse/org.eclipse.lsp4jakarta.lsp4e.core/src/main/java/org/eclipse/lsp4jakarta/lsp4e/JakartaLSConnection.java
+++ b/jakarta.eclipse/org.eclipse.lsp4jakarta.lsp4e.core/src/main/java/org/eclipse/lsp4jakarta/lsp4e/JakartaLSConnection.java
@@ -49,8 +49,8 @@ public class JakartaLSConnection extends ProcessStreamConnectionProvider {
 
         String debugPortString = System.getProperty(getClass().getName() + ".debugPort");
         if (debugPortString != null) {
-            //commands.add("-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address="
-            //             + debugPortString);
+            commands.add("-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address="
+                         + debugPortString);
         }
 
         commands.add("-classpath");

--- a/jakarta.eclipse/org.eclipse.lsp4jakarta.lsp4e.core/src/main/java/org/eclipse/lsp4jakarta/lsp4e/JakartaLanguageClient.java
+++ b/jakarta.eclipse/org.eclipse.lsp4jakarta.lsp4e.core/src/main/java/org/eclipse/lsp4jakarta/lsp4e/JakartaLanguageClient.java
@@ -95,7 +95,7 @@ public class JakartaLanguageClient extends LanguageClientImpl implements Jakarta
     public CompletableFuture<JakartaJavaFileInfo> getJavaFileInfo(JakartaJavaFileInfoParams javaParams) {
         return CompletableFutures.computeAsync(cancelChecker -> {
             IProgressMonitor monitor = getProgressMonitor(cancelChecker);
-            return PropertiesManagerForJava.getInstance().fileInfo(javaParams, JDTUtilsLSImpl.getInstance(), monitor);
+            return PropertiesManagerForJava.getInstance().fileInfo(javaParams, JDTUtilsLSImpl.getInstance());
         });
     }
 

--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/plugin.xml
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/plugin.xml
@@ -16,6 +16,7 @@
 	<!-- Delegate command handler for custom Eclipse LSP4Jakarta commands contributed to Eclipse JDT LS -->
 	<extension point="org.eclipse.jdt.ls.core.delegateCommandHandler">
 		<delegateCommandHandler class="org.eclipse.lsp4jakarta.jdt.internal.core.ls.JakartaDelegateCommandHandlerForJava">
+		    <command id="jakarta/java/fileInfo"/>
 			<command id="jakarta/java/completion"/>
 		    <command id="jakarta/java/codeAction"/>
             <command id="jakarta/java/codeActionResolve"/>

--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/commons/utils/JSONUtility.java
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/commons/utils/JSONUtility.java
@@ -27,71 +27,70 @@ import com.google.gson.JsonElement;
  */
 public class JSONUtility {
 
-	private JSONUtility() {
-	}
+    private JSONUtility() {}
 
-	private static final Gson LSP4J_GSON = new MessageJsonHandler(new HashMap<>()).getGson();
+    private static final Gson LSP4J_GSON = new MessageJsonHandler(new HashMap<>()).getGson();
 
-	private static final Gson EITHER_GSON = new GsonBuilder() //
-			.registerTypeAdapterFactory(new EitherTypeAdapter.Factory()).create();
+    private static final Gson EITHER_GSON = new GsonBuilder() //
+                    .registerTypeAdapterFactory(new EitherTypeAdapter.Factory()).create();
 
-	/**
-	 * Converts the given Object to the given class using lsp4j's GSON logic.
-	 *
-	 * @param <T>    the class to convert the Object to
-	 * @param object the object to convert
-	 * @param clazz  the class to convert the Object to
-	 * @return the given Object converted to the given class using lsp4j's GSON
-	 *         logic
-	 */
-	public static <T> T toModel(Object object, Class<T> clazz) {
-		return toModel(getLsp4jGson(), object, clazz);
-	}
+    /**
+     * Converts the given Object to the given class using lsp4j's GSON logic.
+     *
+     * @param <T> the class to convert the Object to
+     * @param object the object to convert
+     * @param clazz the class to convert the Object to
+     * @return the given Object converted to the given class using lsp4j's GSON
+     *         logic
+     */
+    public static <T> T toModel(Object object, Class<T> clazz) {
+        return toModel(getLsp4jGson(), object, clazz);
+    }
 
-	/**
-	 * Converts the given Object to the given class using the given GSON instance.
-	 *
-	 * @param <T>    the class to convert the Object to
-	 * @param gson   the gson instance to use to perform the conversion
-	 * @param object the object to convert
-	 * @param clazz  the class to convert the Object to
-	 * @return the given Object converted to the given class using the given GSON
-	 *         instance
-	 */
-	public static <T> T toModel(Gson gson, Object object, Class<T> clazz) {
-		if (object == null) {
-			return null;
-		}
-		if (clazz == null) {
-			throw new IllegalArgumentException("Class can not be null");
-		}
-		if (object instanceof JsonElement) {
-			return gson.fromJson((JsonElement) object, clazz);
-		}
-		if (clazz.isInstance(object)) {
-			return clazz.cast(object);
-		}
-		// if nothing else works, try serializing and deserializing again
-		return gson.fromJson(gson.toJson(object), clazz);
-	}
+    /**
+     * Converts the given Object to the given class using the given GSON instance.
+     *
+     * @param <T> the class to convert the Object to
+     * @param gson the gson instance to use to perform the conversion
+     * @param object the object to convert
+     * @param clazz the class to convert the Object to
+     * @return the given Object converted to the given class using the given GSON
+     *         instance
+     */
+    public static <T> T toModel(Gson gson, Object object, Class<T> clazz) {
+        if (object == null) {
+            return null;
+        }
+        if (clazz == null) {
+            throw new IllegalArgumentException("Class can not be null");
+        }
+        if (object instanceof JsonElement) {
+            return gson.fromJson((JsonElement) object, clazz);
+        }
+        if (clazz.isInstance(object)) {
+            return clazz.cast(object);
+        }
+        // if nothing else works, try serializing and deserializing again
+        return gson.fromJson(gson.toJson(object), clazz);
+    }
 
-	/**
-	 * Returns a Gson instance configured similarly to the instance lsp4j uses.
-	 *
-	 * @return a Gson instance configured similarly to the instance lsp4j uses
-	 */
-	public static Gson getLsp4jGson() {
-		return LSP4J_GSON;
-	}
+    /**
+     * Returns a Gson instance configured similarly to the instance lsp4j uses.
+     *
+     * @return a Gson instance configured similarly to the instance lsp4j uses
+     */
+    public static Gson getLsp4jGson() {
+        return LSP4J_GSON;
+    }
 
-	/**
-	 * Returns a Gson instance with most of the default options, but with the
-	 * ability to parse {@code org.eclipse.lsp4j.Either}.
-	 *
-	 * @return a Gson instance with most of the default options, but with the
-	 *         ability to parse {@code org.eclipse.lsp4j.Either}
-	 */
-	public static Gson getEitherGson() {
-		return EITHER_GSON;
-	}
+    /**
+     * Returns a Gson instance with most of the default options, but with the
+     * ability to parse {@code org.eclipse.lsp4j.Either}.
+     *
+     * @return a Gson instance with most of the default options, but with the
+     *         ability to parse {@code org.eclipse.lsp4j.Either}
+     */
+    public static Gson getEitherGson() {
+        return EITHER_GSON;
+    }
 }

--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/core/PropertiesManagerForJava.java
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/core/PropertiesManagerForJava.java
@@ -538,7 +538,7 @@ public class PropertiesManagerForJava {
      * @return the Java file information (ex : package name) from the given file URI
      *         and null otherwise.
      */
-    public JakartaJavaFileInfo fileInfo(JakartaJavaFileInfoParams params, IJDTUtils utils, IProgressMonitor monitor) {
+    public JakartaJavaFileInfo fileInfo(JakartaJavaFileInfoParams params, IJDTUtils utils) {
         String uri = params.getUri();
         final ICompilationUnit unit = utils.resolveCompilationUnit(uri);
         if (unit != null && unit.exists()) {

--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/internal/core/ls/JakartaDelegateCommandHandlerForJava.java
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/internal/core/ls/JakartaDelegateCommandHandlerForJava.java
@@ -44,6 +44,8 @@ import org.eclipse.lsp4jakarta.commons.JakartaJavaCompletionParams;
 import org.eclipse.lsp4jakarta.commons.JakartaJavaCompletionResult;
 import org.eclipse.lsp4jakarta.commons.JakartaJavaDiagnosticsParams;
 import org.eclipse.lsp4jakarta.commons.JakartaJavaDiagnosticsSettings;
+import org.eclipse.lsp4jakarta.commons.JakartaJavaFileInfo;
+import org.eclipse.lsp4jakarta.commons.JakartaJavaFileInfoParams;
 import org.eclipse.lsp4jakarta.commons.JavaCursorContextResult;
 import org.eclipse.lsp4jakarta.commons.codeaction.CodeActionResolveData;
 import org.eclipse.lsp4jakarta.commons.utils.JSONUtility;
@@ -54,6 +56,7 @@ import org.eclipse.lsp4jakarta.jdt.core.PropertiesManagerForJava;
  */
 public class JakartaDelegateCommandHandlerForJava extends AbstractJakartaDelegateCommandHandler {
 
+    private static final String FILE_INFO_COMMAND_ID = "jakarta/java/fileInfo";
     private static final String JAVA_CODEACTION_COMMAND_ID = "jakarta/java/codeAction";
     private static final String JAVA_CODEACTION_RESOLVE_COMMAND_ID = "jakarta/java/codeActionResolve";
     private static final String JAVA_COMPLETION_COMMAND_ID = "jakarta/java/completion";
@@ -74,6 +77,8 @@ public class JakartaDelegateCommandHandlerForJava extends AbstractJakartaDelegat
     public Object executeCommand(String commandId, List<Object> arguments, IProgressMonitor monitor) throws Exception {
         JavaLanguageServerPlugin.logInfo(String.format("Executing command '%s' in LSP4Jakarta JDT LS extension", commandId));
         switch (commandId) {
+            case FILE_INFO_COMMAND_ID:
+                return getFileInfo(arguments, commandId);
             case JAVA_CODEACTION_COMMAND_ID:
                 return getCodeActionForJava(arguments, commandId, monitor);
             case JAVA_CODEACTION_RESOLVE_COMMAND_ID:
@@ -85,6 +90,49 @@ public class JakartaDelegateCommandHandlerForJava extends AbstractJakartaDelegat
             default:
                 throw new UnsupportedOperationException(String.format("Unsupported command '%s'!", commandId));
         }
+    }
+
+    /**
+     * Returns the file information (package name, etc) for the given Java file.
+     *
+     * @param arguments
+     * @param commandId
+     * @param monitor
+     * @return the file information (package name, etc) for the given Java file.
+     * @throws CoreException
+     * @throws JavaModelException
+     */
+    private static JakartaJavaFileInfo getFileInfo(List<Object> arguments, String commandId) throws JavaModelException, CoreException {
+        // Create java file information parameter
+        JakartaJavaFileInfoParams params = createJavaFileInfoParams(arguments, commandId);
+        // Return file information from the parameter
+        return PropertiesManagerForJava.getInstance().fileInfo(params, JDTUtilsLSImpl.getInstance());
+    }
+
+    /**
+     * Create the Java file information parameter from the given arguments map.
+     *
+     * @param arguments
+     * @param commandId
+     *
+     * @return the Java file information parameter.
+     */
+    private static JakartaJavaFileInfoParams createJavaFileInfoParams(List<Object> arguments, String commandId) {
+        Map<String, Object> obj = getFirst(arguments);
+        if (obj == null) {
+            throw new UnsupportedOperationException(String.format(
+                                                                  "Command '%s' must be called with one MicroProfileJavaFileInfoParams argument!", commandId));
+        }
+        // Get project name from the java file URI
+        String javaFileUri = getString(obj, "uri");
+        if (javaFileUri == null) {
+            throw new UnsupportedOperationException(String.format(
+                                                                  "Command '%s' must be called with required MicroProfileJavaFileInfoParams.uri (java file URI)!",
+                                                                  commandId));
+        }
+        JakartaJavaFileInfoParams params = new JakartaJavaFileInfoParams();
+        params.setUri(javaFileUri);
+        return params;
     }
 
     /**

--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/internal/core/ls/JakartaDelegateCommandHandlerForJava.java
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/internal/core/ls/JakartaDelegateCommandHandlerForJava.java
@@ -121,13 +121,13 @@ public class JakartaDelegateCommandHandlerForJava extends AbstractJakartaDelegat
         Map<String, Object> obj = getFirst(arguments);
         if (obj == null) {
             throw new UnsupportedOperationException(String.format(
-                                                                  "Command '%s' must be called with one MicroProfileJavaFileInfoParams argument!", commandId));
+                                                                  "Command '%s' must be called with one JakartaJavaFileInfoParams argument!", commandId));
         }
         // Get project name from the java file URI
         String javaFileUri = getString(obj, "uri");
         if (javaFileUri == null) {
             throw new UnsupportedOperationException(String.format(
-                                                                  "Command '%s' must be called with required MicroProfileJavaFileInfoParams.uri (java file URI)!",
+                                                                  "Command '%s' must be called with required JakartaJavaFileInfoParams.uri (java file URI)!",
                                                                   commandId));
         }
         JakartaJavaFileInfoParams params = new JakartaJavaFileInfoParams();


### PR DESCRIPTION
there is a new "jakarta/java/fileInfo" message supported between LS and LSClient to get the package name file in for the file that is currently having a snippet inserted into it. This was not functioning in the vscode env because the config for that new message was missing from the DelegateCommandHandler and the vscode client config as well. Added this support so that package name can be obtained from the jakarta JDT LS extn. There is a separate PR int he liberty-tools-vscode repo to pick up the tool config side of this. 