### PR TITLE
Export all commons.* packages from jakarta.jdt bundle

### DIFF
--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/META-INF/MANIFEST.MF
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/META-INF/MANIFEST.MF
@@ -28,6 +28,8 @@ Bundle-ActivationPolicy: lazy
 Bundle-ClassPath: .
 Export-Package: 
  org.eclipse.lsp4jakarta.commons,
+ org.eclipse.lsp4jakarta.commons.codeaction,
+ org.eclipse.lsp4jakarta.commons.utils,
  org.eclipse.lsp4jakarta.jdt.core,
  org.eclipse.lsp4jakarta.jdt.core.utils,
  org.eclipse.lsp4jakarta.jdt.internal.core.ls


### PR DESCRIPTION
Without this I hit a ClassCastException when trying to resolve a code action from the LSP4MP.

I was running into a scenario where one path resolved the code action data directly from the lsp4e bundle and the other path accessed it via my "client" bundle.  The client also packages the "commons*" classes, but if we export them from jakarta.jdt we will consistently load them from this bundle rather than using our local client-packaged classes.

Leaving aside the other difficulties with the LSP4MP code action above, it seemed like this could be fixed independently.