### PR TITLE
Update junit dependency version

### DIFF
--- a/jakarta.eclipse/pom.xml
+++ b/jakarta.eclipse/pom.xml
@@ -26,8 +26,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
-        <tycho.version>2.7.2</tycho.version>
-        <tycho.extras.version>${tycho.version}</tycho.extras.version>
+        <tycho.version>3.0.3</tycho.version>
         <tycho.test.platformArgs />
         <tycho.test.jvmArgs>-Xmx512m ${tycho.test.platformArgs}</tycho.test.jvmArgs>
     </properties>
@@ -139,15 +138,15 @@
             <build>
                 <plugins>
                     <plugin>
-                        <groupId>org.eclipse.tycho.extras</groupId>
-                        <artifactId>tycho-source-feature-plugin</artifactId>
-                        <version>${tycho.extras.version}</version>
+                        <groupId>org.eclipse.tycho</groupId>
+                        <artifactId>tycho-source-plugin</artifactId>
+                        <version>${tycho.version}</version>
                         <executions>
                             <execution>
-                                <id>source-feature</id>
+                                <id>feature-source</id>
                                 <phase>package</phase>
                                 <goals>
-                                    <goal>source-feature</goal>
+                                    <goal>feature-source</goal>
                                 </goals>
                             </execution>
                         </executions>

--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.test/projects/demo-servlet-no-diagnostics/pom.xml
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.test/projects/demo-servlet-no-diagnostics/pom.xml
@@ -34,7 +34,7 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.12</version>
+            <version>4.13.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -80,7 +80,7 @@
             <plugin>
                 <groupId>io.openliberty.tools</groupId>
                 <artifactId>liberty-maven-plugin</artifactId>
-                <version>3.9</version>
+                <version>3.10</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.test/projects/jakarta-sample/pom.xml
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.test/projects/jakarta-sample/pom.xml
@@ -34,7 +34,7 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.12</version>
+            <version>4.13.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -80,7 +80,7 @@
             <plugin>
                 <groupId>io.openliberty.tools</groupId>
                 <artifactId>liberty-maven-plugin</artifactId>
-                <version>3.9</version>
+                <version>3.10</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/jakarta.jdt/pom.xml
+++ b/jakarta.jdt/pom.xml
@@ -33,7 +33,6 @@
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
         <tycho.version>3.0.3</tycho.version>
-        <tycho.extras.version>${tycho.version}</tycho.extras.version>
         <tycho.scmUrl>scm:git:https://github.com/eclipse/lsp4jakarta</tycho.scmUrl>
         <tycho.generateSourceReferences>true</tycho.generateSourceReferences>
         <jdt.ls.version>1.21.0.20230316144047</jdt.ls.version>

--- a/jakarta.ls/pom.xml
+++ b/jakarta.ls/pom.xml
@@ -52,7 +52,7 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.11</version>
+            <version>4.13.2</version>
             <scope>test</scope>
         </dependency>
         <!-- https://mvnrepository.com/artifact/com.google.guava/guava -->


### PR DESCRIPTION
This PR:
- Updates the JUnit dependency version to fix maven repository reported vulnerability (lsp4jakarta.ls).
- Updates the Liberty Maven Plugin version used by test projects. 
- Cleanup.