### PR TITLE
Remove diagnostic for managed bean public field with invalid scope

### DIFF
--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/internal/cdi/ErrorCode.java
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/internal/cdi/ErrorCode.java
@@ -20,7 +20,6 @@ import org.eclipse.lsp4jakarta.jdt.core.java.diagnostics.IJavaErrorCode;
 public enum ErrorCode implements IJavaErrorCode {
     InvalidNumberOfScopedAnnotationsByManagedBean,
     InvalidManagedBeanWithNonStaticPublicField,
-    InvalidManagedBeanWithNonStaticPublicFieldInvalidScope,
     InvalidNumberOfScopeAnnotationsByProducerField,
     InvalidFieldWithProducesAndInjectAnnotations,
     InvalidNumberOfScopeAnnotationsByProducerMethod,

--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/internal/cdi/ManagedBeanDiagnosticsParticipant.java
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/internal/cdi/ManagedBeanDiagnosticsParticipant.java
@@ -86,7 +86,11 @@ public class ManagedBeanDiagnosticsParticipant implements IJavaDiagnosticsPartic
                 List<String> fieldScopes = DiagnosticUtils.getMatchedJavaElementNames(type, annotationNames,
                                                                                       scopeFQNames);
 
-                // If a managed bean has a non-static public field, it must have scope @Dependent.
+                // If a managed bean has a non-static public field, it must have
+                // scope @Dependent. If a managed bean with a non-static public field declares
+                // any scope other than @Dependent, the container automatically detects the
+                // problem and treats it as a definition error.
+                //
                 // https://jakarta.ee/specifications/cdi/3.0/jakarta-cdi-spec-3.0.html#managed_beans
                 if (isManagedBean && Flags.isPublic(fieldFlags) && !Flags.isStatic(fieldFlags)
                     && !managedBeanAnnotations.contains(Constants.DEPENDENT_FQ_NAME)) {
@@ -95,18 +99,6 @@ public class ManagedBeanDiagnosticsParticipant implements IJavaDiagnosticsPartic
                                                              Messages.getMessage("ManagedBeanWithNonStaticPublicField"), range,
                                                              Constants.DIAGNOSTIC_SOURCE, null,
                                                              ErrorCode.InvalidManagedBeanWithNonStaticPublicField, DiagnosticSeverity.Error));
-                }
-
-                // If a managed bean with a non-static public field declares any scope other than @Dependent,
-                // the container automatically detects the problem and treats it as a definition error.
-                // https://jakarta.ee/specifications/cdi/3.0/jakarta-cdi-spec-3.0.html#managed_beans
-                if (isManagedBean && Flags.isPublic(fieldFlags) && !Flags.isStatic(fieldFlags)
-                    && fieldScopes.size() == 1 && !fieldScopes.get(0).equals(Constants.DEPENDENT_FQ_NAME)) {
-                    Range range = PositionUtils.toNameRange(field, context.getUtils());
-                    diagnostics.add(context.createDiagnostic(uri,
-                                                             Messages.getMessage("ManagedBeanWithNonStaticPublicFieldInvalidScope"), range,
-                                                             Constants.DIAGNOSTIC_SOURCE, null,
-                                                             ErrorCode.InvalidManagedBeanWithNonStaticPublicFieldInvalidScope, DiagnosticSeverity.Error));
                 }
 
                 // https://jakarta.ee/specifications/cdi/3.0/jakarta-cdi-spec-3.0.html#declaring_bean_scope

--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/resources/org/eclipse/lsp4jakarta/jdt/core/messages/messages.properties
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/resources/org/eclipse/lsp4jakarta/jdt/core/messages/messages.properties
@@ -61,7 +61,6 @@ ScopeTypeAnnotationsManagedBean = Scope type annotations must be specified by a 
 ScopeTypeAnnotationsProducerField = Scope type annotations must be specified by a producer field at most once.
 ScopeTypeAnnotationsProducerMethod = Scope type annotations must be specified by a producer method at most once.
 ManagedBeanWithNonStaticPublicField = The @Dependent annotation must be defined by a managed bean with a non-static public field.
-ManagedBeanWithNonStaticPublicFieldInvalidScope = The @Dependent annotation must be the only scope defined by a non-static public field.
 ManagedBeanConstructorWithParameters = The @Inject annotation must define a managed bean constructor that takes parameters, or the managed bean must resolve to having a no-arg constructor instead.
 ManagedBeanDisposeOneParameter = The @Disposes annotation must not be defined on more than one parameter of a method.
 ManagedBeanInvalidDisposer = A disposer method cannot have parameter(s) annotated with {0}.

--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.test/src/main/java/org/eclipse/lsp4jakarta/jdt/cdi/ManagedBeanTest.java
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.test/src/main/java/org/eclipse/lsp4jakarta/jdt/cdi/ManagedBeanTest.java
@@ -55,29 +55,26 @@ public class ManagedBeanTest extends BaseJakartaTest {
         Diagnostic d1 = d(9, 12, 13,
                           "The @Dependent annotation must be defined by a managed bean with a non-static public field.",
                           DiagnosticSeverity.Error, "jakarta-cdi", "InvalidManagedBeanWithNonStaticPublicField");
-        Diagnostic d2 = d(9, 12, 13,
-                          "The @Dependent annotation must be the only scope defined by a non-static public field.",
-                          DiagnosticSeverity.Error, "jakarta-cdi", "InvalidManagedBeanWithNonStaticPublicFieldInvalidScope");
-        Diagnostic d3 = d(6, 12, 13,
+        Diagnostic d2 = d(6, 12, 13,
                           "The @Dependent annotation must be defined by a managed bean with a non-static public field.",
                           DiagnosticSeverity.Error, "jakarta-cdi", "InvalidManagedBeanWithNonStaticPublicField");
-        Diagnostic d4 = d(5, 13, 24,
+        Diagnostic d3 = d(5, 13, 24,
                           "Managed bean class of generic type must have scope @Dependent.",
                           DiagnosticSeverity.Error, "jakarta-cdi", "InvalidGenericManagedBeanClassWithNoDependentScope");
 
-        assertJavaDiagnostics(diagnosticsParams, IJDT_UTILS, d1, d2, d3, d4);
+        assertJavaDiagnostics(diagnosticsParams, IJDT_UTILS, d1, d2, d3);
+
+        // Assert for diagnostic d2
+        JakartaJavaCodeActionParams codeActionParams1 = createCodeActionParams(uri, d2);
+        TextEdit te2 = te(4, 0, 5, 0, "@Dependent\n");
+        CodeAction ca2 = ca(uri, "Replace current scope with @Dependent", d2, te2);
+        assertJavaCodeAction(codeActionParams1, IJDT_UTILS, ca2);
 
         // Assert for diagnostic d3
-        JakartaJavaCodeActionParams codeActionParams1 = createCodeActionParams(uri, d3);
+        JakartaJavaCodeActionParams codeActionParams2 = createCodeActionParams(uri, d3);
         TextEdit te3 = te(4, 0, 5, 0, "@Dependent\n");
         CodeAction ca3 = ca(uri, "Replace current scope with @Dependent", d3, te3);
-        assertJavaCodeAction(codeActionParams1, IJDT_UTILS, ca3);
-
-        // Assert for diagnostic d4
-        JakartaJavaCodeActionParams codeActionParams2 = createCodeActionParams(uri, d4);
-        TextEdit te4 = te(4, 0, 5, 0, "@Dependent\n");
-        CodeAction ca4 = ca(uri, "Replace current scope with @Dependent", d4, te4);
-        assertJavaCodeAction(codeActionParams2, IJDT_UTILS, ca4);
+        assertJavaCodeAction(codeActionParams2, IJDT_UTILS, ca3);
     }
 
     @Test


### PR DESCRIPTION
We clarified this rule with the Liberty CDI team and decided the latest added diagnostic is not correct. The fix for the original diagnostic is correct. The issue #534 has a bit more explanation.

https://jakarta.ee/specifications/cdi/3.0/jakarta-cdi-spec-3.0.html#managed_beans

Fixes #534 