### PR TITLE
Fixes #416 - Quick-fix fails due to getData() is null

### DIFF
--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/internal/beanvalidation/RemoveDynamicConstraintAnnotationQuickFix.java
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/internal/beanvalidation/RemoveDynamicConstraintAnnotationQuickFix.java
@@ -64,7 +64,6 @@ public class RemoveDynamicConstraintAnnotationQuickFix implements IJavaCodeActio
     @Override
     public List<? extends CodeAction> getCodeActions(JavaCodeActionContext context, Diagnostic diagnostic,
                                                      IProgressMonitor monitor) throws CoreException {
-        LOGGER.log(Level.SEVERE, "Diagnostics data ============",diagnostic);                                         
         String annotationName = diagnostic.getData().toString().replace("\"", "");
         String label = getLabel(annotationName);
         ASTNode node = context.getCoveredNode();

--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/internal/beanvalidation/RemoveDynamicConstraintAnnotationQuickFix.java
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/internal/beanvalidation/RemoveDynamicConstraintAnnotationQuickFix.java
@@ -64,6 +64,7 @@ public class RemoveDynamicConstraintAnnotationQuickFix implements IJavaCodeActio
     @Override
     public List<? extends CodeAction> getCodeActions(JavaCodeActionContext context, Diagnostic diagnostic,
                                                      IProgressMonitor monitor) throws CoreException {
+        LOGGER.log(Level.SEVERE, "Diagnostics data ============",diagnostic);                                         
         String annotationName = diagnostic.getData().toString().replace("\"", "");
         String label = getLabel(annotationName);
         ASTNode node = context.getCoveredNode();

--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/internal/core/ls/ArgumentUtils.java
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/internal/core/ls/ArgumentUtils.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2019, 2023 Red Hat Inc. and others.
+* Copyright (c) 2019, 2024 Red Hat Inc. and others.
 *
 * This program and the accompanying materials are made available under the
 * terms of the Eclipse Public License v. 2.0 which is available at
@@ -23,12 +23,9 @@ import org.eclipse.lsp4j.Diagnostic;
 import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.Range;
 import org.eclipse.lsp4j.TextDocumentIdentifier;
-import org.eclipse.lsp4jakarta.jdt.internal.beanvalidation.RemoveDynamicConstraintAnnotationQuickFix;
 
 import com.google.gson.Gson;
 import com.google.gson.JsonArray;
-import com.google.gson.JsonObject;
-import com.google.gson.JsonParser;
 
 /**
  * Arguments utilities.

--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/internal/core/ls/ArgumentUtils.java
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/internal/core/ls/ArgumentUtils.java
@@ -147,32 +147,34 @@ public class ArgumentUtils {
     }
 
     /**
-     * Returns the child as a JSON array if the data parameter contains an array of strings; otherwise, 
-     * returns it as an object if present, or null if not.
-     *
-     *
-     * @param data the object to get the child of
-     * @param key the key of the child
-     * @return Returns the child as a JSON array if the data parameter contains an array of strings; otherwise, 
-     * returns it as an object if present, or null if not.
-     */
+	 * Returns the child as a JSON array if the data parameter contains an array of
+	 * strings; otherwise,
+	 * returns it as an object if present, or null if not.
+	 *
+	 *
+	 * @param data the object to get the child of
+	 * @param key  the key of the child
+	 * @return Returns the child as a JSON array if the data parameter contains an
+	 *         array of strings; otherwise,
+	 *         returns it as an object if present, or null if not.
+	 */
     public static Object getValueFromDataParameter(Map<String, Object> data, String key) {
 
-        Object child = data.get(key);
-        if (child != null && child instanceof String) {
-        	// if the value in the 'data' is a string, we string the object. 
-        	// eg: data = “AssertTrue”
-            return child;
-        } else if (child instanceof List<?>) {
-        	// if the value in the 'data' is an array, we will convert it to an JsonArray.
-        	// eg: data =[“ApplicationScoped", "RequestScoped”]
-            Gson gson = new Gson();
-            JsonArray jsonArray = gson.toJsonTree(child).getAsJsonArray();
-            return jsonArray;
-        } else {
-        	//Returns the object if it exists and is an object, and null otherwise
-            return getObject(data, key);
-        }
+    	Object child = data.get(key);
+    	if (child instanceof String) {
+    		// if the value in the 'data' is a string, we string the object.
+    		// eg: data = “AssertTrue”
+    		return child;
+    	} else if (child instanceof List<?>) {
+    		// if the value in the 'data' is an array, we will convert it to an JsonArray.
+    		// eg: data =[“ApplicationScoped", "RequestScoped”]
+    		Gson gson = new Gson();
+    		JsonArray jsonArray = gson.toJsonTree(child).getAsJsonArray();
+    		return jsonArray;
+    	} else {
+    		// Returns the object if it exists and is an object, and null otherwise
+    		return getObject(data, key);
+    	}
 
     }
 }

--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/internal/core/ls/ArgumentUtils.java
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/internal/core/ls/ArgumentUtils.java
@@ -147,34 +147,32 @@ public class ArgumentUtils {
     }
 
     /**
-	 * Returns the child as a JSON array if the data parameter contains an array of
-	 * strings; otherwise,
-	 * returns it as an object if present, or null if not.
-	 *
-	 *
-	 * @param data the object to get the child of
-	 * @param key  the key of the child
-	 * @return Returns the child as a JSON array if the data parameter contains an
-	 *         array of strings; otherwise,
-	 *         returns it as an object if present, or null if not.
-	 */
+     * Returns the child as a JSON array if the data parameter contains an array of strings; otherwise, 
+     * returns it as an object if present, or null if not.
+     *
+     *
+     * @param data the object to get the child of
+     * @param key the key of the child
+     * @return Returns the child as a JSON array if the data parameter contains an array of strings; otherwise, 
+     * returns null.
+     */
     public static Object getValueFromDataParameter(Map<String, Object> data, String key) {
 
-    	Object child = data.get(key);
-    	if (child instanceof String) {
-    		// if the value in the 'data' is a string, we string the object.
-    		// eg: data = “AssertTrue”
-    		return child;
-    	} else if (child instanceof List<?>) {
-    		// if the value in the 'data' is an array, we will convert it to an JsonArray.
-    		// eg: data =[“ApplicationScoped", "RequestScoped”]
-    		Gson gson = new Gson();
-    		JsonArray jsonArray = gson.toJsonTree(child).getAsJsonArray();
-    		return jsonArray;
-    	} else {
-    		// Returns null if it is in any other format.
-    		return null;
-    	}
+        Object child = data.get(key);
+        if (child instanceof String) {
+            // if the value in the 'data' is a string, we string the object. 
+        	// eg: data = “AssertTrue”
+            return child;
+        } else if (child instanceof List<?>) {
+        	// if the value in the 'data' is an array, we will convert it to an JsonArray.
+        	// eg: data =[“ApplicationScoped", "RequestScoped”]
+            Gson gson = new Gson();
+            JsonArray jsonArray = gson.toJsonTree(child).getAsJsonArray();
+            return jsonArray;
+        } else {
+        	// Returns null if it is in any other format.
+            return null;
+        }
 
     }
 }

--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/internal/core/ls/ArgumentUtils.java
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/internal/core/ls/ArgumentUtils.java
@@ -172,8 +172,8 @@ public class ArgumentUtils {
     		JsonArray jsonArray = gson.toJsonTree(child).getAsJsonArray();
     		return jsonArray;
     	} else {
-    		// Returns the object if it exists and is an object, and null otherwise
-    		return getObject(data, key);
+    		// Returns null if it is in any other format.
+    		return null;
     	}
 
     }

--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/internal/core/ls/ArgumentUtils.java
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/internal/core/ls/ArgumentUtils.java
@@ -161,16 +161,16 @@ public class ArgumentUtils {
         Object child = data.get(key);
         if (child instanceof String) {
             // if the value in the 'data' is a string, we string the object. 
-        	// eg: data = “AssertTrue”
+            // eg: data = “AssertTrue”
             return child;
         } else if (child instanceof List<?>) {
-        	// if the value in the 'data' is an array, we will convert it to an JsonArray.
-        	// eg: data =[“ApplicationScoped", "RequestScoped”]
+            // if the value in the 'data' is an array, we will convert it to an JsonArray.
+            // eg: data =[“ApplicationScoped", "RequestScoped”]
             Gson gson = new Gson();
             JsonArray jsonArray = gson.toJsonTree(child).getAsJsonArray();
             return jsonArray;
         } else {
-        	// Returns null if it is in any other format.
+            // Returns null if it is in any other format.
             return null;
         }
 


### PR DESCRIPTION
Fixes #416 

Quick-fix fails due to getData() is null.
 The root cause of the issue is lsp4Jakarta expects a Map object from VS Code, but we are sending a string or array of strings from VS code. Resolved the null pointer exception by adding code to handle both the 'data' format.

eg:
data = “AssertTrue”
data =[“ApplicationScoped", "RequestScoped”]
