### PR TITLE
Remove a quick fix that removes both annotations when the two are mutually exclusive

### DIFF
--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/plugin.xml
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/plugin.xml
@@ -310,11 +310,14 @@
       <codeAction kind="quickfix"
                   targetDiagnostic="jakarta-cdi#InvalidProducerMethodParamAnnotation"
                   class="org.eclipse.lsp4jakarta.jdt.internal.cdi.RemoveProduceAnnotationQuickFix" />
+      <!-- These quick fixes remove remove the @Disposes annotation as well as the @Observes annotation.
+           They are mutually exclusive and only one needs to go.
       <codeAction kind="quickfix"
                   targetDiagnostic="jakarta-cdi#InvalidDisposesAnnotationOnMultipleMethodParams"
                   class="org.eclipse.lsp4jakarta.jdt.internal.cdi.RemoveInvalidProducerParamAnnotationQuickFix" />
-       <codeAction kind="quickfix"
+      <codeAction kind="quickfix"
                   targetDiagnostic="jakarta-cdi#InvalidDisposerMethodParamAnnotation"
                   class="org.eclipse.lsp4jakarta.jdt.internal.cdi.RemoveInvalidProducerParamAnnotationQuickFix" />
+      -->
    </extension>
 </plugin>

--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.test/src/main/java/org/eclipse/lsp4jakarta/jdt/cdi/ManagedBeanTest.java
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.test/src/main/java/org/eclipse/lsp4jakarta/jdt/cdi/ManagedBeanTest.java
@@ -438,42 +438,45 @@ public class ManagedBeanTest extends BaseJakartaTest {
 
         assertJavaCodeAction(codeActionParams8, IJDT_UTILS, ca20, ca21);
 
-        JakartaJavaCodeActionParams codeActionParams9 = createCodeActionParams(uri, d9);
-
-        TextEdit te22 = te(30, 40, 30, 50, "");
-        TextEdit te23 = te(30, 64, 30, 74, "");
-        CodeAction ca22 = ca(uri, "Remove the '@Disposes' modifier from parameter 'name1'", d9, te22);
-        CodeAction ca23 = ca(uri, "Remove the '@Observes' modifier from parameter 'name2'", d9, te23);
-
-        assertJavaCodeAction(codeActionParams9, IJDT_UTILS, ca22, ca23);
-
-        JakartaJavaCodeActionParams codeActionParams10 = createCodeActionParams(uri, d10);
-
-        TextEdit te24 = te(42, 45, 42, 55, "");
-        TextEdit te25 = te(42, 69, 42, 84, "");
-        CodeAction ca24 = ca(uri, "Remove the '@Disposes' modifier from parameter 'name1'", d10, te24);
-        CodeAction ca25 = ca(uri, "Remove the '@ObservesAsync' modifier from parameter 'name2'", d10, te25);
-
-        assertJavaCodeAction(codeActionParams10, IJDT_UTILS, ca24, ca25);
-
-        JakartaJavaCodeActionParams codeActionParams11 = createCodeActionParams(uri, d11);
-
-        TextEdit te26 = te(48, 53, 48, 63, "");
-        TextEdit te27 = te(48, 77, 48, 87, "");
-        TextEdit te28 = te(48, 101, 48, 116, "");
-        CodeAction ca26 = ca(uri, "Remove the '@Disposes' modifier from parameter 'name1'", d11, te26);
-        CodeAction ca27 = ca(uri, "Remove the '@Observes' modifier from parameter 'name2'", d11, te27);
-        CodeAction ca28 = ca(uri, "Remove the '@ObservesAsync' modifier from parameter 'name3'", d11, te28);
-
-        assertJavaCodeAction(codeActionParams11, IJDT_UTILS, ca26, ca27, ca28);
-
-        JakartaJavaCodeActionParams codeActionParams12 = createCodeActionParams(uri, d12);
-
-        TextEdit te30 = te(54, 54, 54, 89, "");
-        CodeAction ca30 = ca(uri,
-                             "Remove the '@Disposes', '@Observes', '@ObservesAsync' modifier from parameter 'name'", d12, te30);
-
-        assertJavaCodeAction(codeActionParams12, IJDT_UTILS, ca30);
+        /*
+         * These code actions are disabled until they are fixed
+         * JakartaJavaCodeActionParams codeActionParams9 = createCodeActionParams(uri, d9);
+         *
+         * TextEdit te22 = te(30, 40, 30, 50, "");
+         * TextEdit te23 = te(30, 64, 30, 74, "");
+         * CodeAction ca22 = ca(uri, "Remove the '@Disposes' modifier from parameter 'name1'", d9, te22);
+         * CodeAction ca23 = ca(uri, "Remove the '@Observes' modifier from parameter 'name2'", d9, te23);
+         *
+         * assertJavaCodeAction(codeActionParams9, IJDT_UTILS, ca22, ca23);
+         *
+         * JakartaJavaCodeActionParams codeActionParams10 = createCodeActionParams(uri, d10);
+         *
+         * TextEdit te24 = te(42, 45, 42, 55, "");
+         * TextEdit te25 = te(42, 69, 42, 84, "");
+         * CodeAction ca24 = ca(uri, "Remove the '@Disposes' modifier from parameter 'name1'", d10, te24);
+         * CodeAction ca25 = ca(uri, "Remove the '@ObservesAsync' modifier from parameter 'name2'", d10, te25);
+         *
+         * assertJavaCodeAction(codeActionParams10, IJDT_UTILS, ca24, ca25);
+         *
+         * JakartaJavaCodeActionParams codeActionParams11 = createCodeActionParams(uri, d11);
+         *
+         * TextEdit te26 = te(48, 53, 48, 63, "");
+         * TextEdit te27 = te(48, 77, 48, 87, "");
+         * TextEdit te28 = te(48, 101, 48, 116, "");
+         * CodeAction ca26 = ca(uri, "Remove the '@Disposes' modifier from parameter 'name1'", d11, te26);
+         * CodeAction ca27 = ca(uri, "Remove the '@Observes' modifier from parameter 'name2'", d11, te27);
+         * CodeAction ca28 = ca(uri, "Remove the '@ObservesAsync' modifier from parameter 'name3'", d11, te28);
+         *
+         * assertJavaCodeAction(codeActionParams11, IJDT_UTILS, ca26, ca27, ca28);
+         *
+         * JakartaJavaCodeActionParams codeActionParams12 = createCodeActionParams(uri, d12);
+         *
+         * TextEdit te30 = te(54, 54, 54, 89, "");
+         * CodeAction ca30 = ca(uri,
+         * "Remove the '@Disposes', '@Observes', '@ObservesAsync' modifier from parameter 'name'", d12, te30);
+         *
+         * assertJavaCodeAction(codeActionParams12, IJDT_UTILS, ca30);
+         */
     }
 
     @Test


### PR DESCRIPTION
Pull request #511 added a quick fix which removes all three annotations from a parameter when some of the annotations are in conflict. E.g. "@Disposes @Observes @ObservesAsync String name" There should be two quick fixes, one that removes @Disposes and one that removes @Observes and @ObservesAsync. 

In this pull request we temporarily remove the quick fix from two situations along with the tests that validate them. There is an issue open to fix the code so we can restore the quick fix.