### PR TITLE
Removed the log statement added to track the code action data received in Jakarta server.

### DIFF
--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/internal/core/ls/ArgumentUtils.java
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/internal/core/ls/ArgumentUtils.java
@@ -111,7 +111,6 @@ public class ArgumentUtils {
         }
         List<Map<String, Object>> diagnosticsObj = (List<Map<String, Object>>) contextObj.get(DIAGNOSTICS_PROPERTY);
         List<Diagnostic> diagnostics = diagnosticsObj.stream().map(diagnosticObj -> {
-            LOGGER.info("Received diagnostic data" + diagnosticObj.toString());
             Diagnostic diagnostic = new Diagnostic();
             diagnostic.setRange(getRange(diagnosticObj, RANGE_PROPERTY));
             diagnostic.setCode(getString(diagnosticObj, CODE_PROPERTY));


### PR DESCRIPTION
Fixes #541 

Remove the recently added log statement used to track code action data received on the Jakarta server. This log prints frequently in the VS Code console, and when the log level is changed to debug, it does not appear in the console despite the trace being set to "verbose."