### PR TITLE
Update comments for PersistenceMapKeyDiagnosticsParticipant -  MapKey and MapKeyClass annotations

### DIFF
--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/internal/persistence/PersistenceMapKeyDiagnosticsParticipant.java
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/internal/persistence/PersistenceMapKeyDiagnosticsParticipant.java
@@ -145,7 +145,10 @@ public class PersistenceMapKeyDiagnosticsParticipant implements IJavaDiagnostics
             }
 
             if (hasMapKeyAnnotation && hasMapKeyClassAnnotation) {
-                // A single field cannot have the same
+                //A single method/field cannot be annotated with both @MapKey and @MapKeyClass
+                //Specification References:
+                //https://jakarta.ee/specifications/persistence/3.2/apidocs/jakarta.persistence/jakarta/persistence/mapkey
+                //https://jakarta.ee/specifications/persistence/3.2/apidocs/jakarta.persistence/jakarta/persistence/mapkeyclass
                 Range range = null;
                 String messageKey = null;
                 ErrorCode errorCode = null;


### PR DESCRIPTION
Fix for https://github.com/eclipse-lsp4jakarta/lsp4jakarta/issues/533
Verify that PersistenceMapKeyDiagnosticsParticipant is checking the correct constraint for annotations