### PR TITLE
Code Action to Remove Annotation Fails with Fully Qualified Annotation Names

### DIFF
--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/core/java/corrections/proposal/RemoveAnnotationProposal.java
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/core/java/corrections/proposal/RemoveAnnotationProposal.java
@@ -33,6 +33,7 @@ import org.eclipse.jdt.core.dom.rewrite.ImportRewrite.ImportRewriteContext;
 import org.eclipse.jdt.internal.core.manipulation.dom.ASTResolving;
 import org.eclipse.jdt.internal.corext.codemanipulation.ContextSensitiveImportRewriteContext;
 import org.eclipse.lsp4j.CodeActionKind;
+import org.eclipse.lsp4jakarta.jdt.internal.DiagnosticUtils;
 
 /**
  *
@@ -119,7 +120,7 @@ public class RemoveAnnotationProposal extends ASTRewriteCorrectionProposal {
                     Annotation annotation = (Annotation) child;
                     // IAnnotationBinding annotationBinding = annotation.resolveAnnotationBinding();
 
-                    boolean containsAnnotation = Arrays.stream(annotationShortNames).anyMatch(annotation.getTypeName().toString()::equals);
+                    boolean containsAnnotation = Arrays.stream(annotationShortNames).anyMatch(DiagnosticUtils.getSimpleName(annotation.getTypeName().toString())::equals);
                     if (containsAnnotation) {
                         rewrite.remove(child, null);
                     }


### PR DESCRIPTION
Code Action to Remove Annotation Fails with Fully Qualified Annotation Names. Ideally, it should be able to remove the specific annotation even when the fully qualified name is used.
The same functionality works in IntelliJ.
defect link -> https://github.com/eclipse-lsp4jakarta/lsp4jakarta/issues/567
This defect was identified as part of the investigation I performed while analyzing https://github.com/eclipse-lsp4jakarta/lsp4jakarta/issues/507