### PR TITLE
Increase the tycho test timeout from 60s to 600s

### DIFF
--- a/jakarta.eclipse/pom.xml
+++ b/jakarta.eclipse/pom.xml
@@ -108,9 +108,9 @@
                     <configuration>
                         <useUIHarness>true</useUIHarness>
                         <argLine>${tycho.test.jvmArgs}</argLine>
-                        <!-- kill test JVM if tests take more than 1 minute (60 seconds) to
-                            finish -->
-                        <forkedProcessTimeoutInSeconds>60</forkedProcessTimeoutInSeconds>
+                        <!-- kill test JVM if tests take more than 10 minutes (600 seconds) to
+                            finish. This depends on speed of VM but current runs are 180s. -->
+                        <forkedProcessTimeoutInSeconds>600</forkedProcessTimeoutInSeconds>
                     </configuration>
                 </plugin>
             </plugins>

--- a/jakarta.jdt/pom.xml
+++ b/jakarta.jdt/pom.xml
@@ -138,9 +138,9 @@
                     <configuration>
                         <useUIHarness>false</useUIHarness>
                         <argLine>-Xmx512m</argLine>
-                        <!-- kill test JVM if tests take more than 1 minute (60 seconds) to
-                            finish -->
-                        <forkedProcessTimeoutInSeconds>60</forkedProcessTimeoutInSeconds>
+                        <!-- kill test JVM if tests take more than 10 minutes (600 seconds) to
+                            finish. This depends on speed of VM but current runs are 180s. -->
+                        <forkedProcessTimeoutInSeconds>600</forkedProcessTimeoutInSeconds>
                     </configuration>
                 </plugin>
             </plugins>
@@ -163,9 +163,9 @@
                         <configuration>
                             <useUIHarness>false</useUIHarness>
                             <argLine>-Xmx512m -XstartOnFirstThread</argLine>
-                            <!-- kill test JVM if tests take more than 1 minute (60 seconds) to
-                                finish -->
-                            <forkedProcessTimeoutInSeconds>60</forkedProcessTimeoutInSeconds>
+                            <!-- kill test JVM if tests take more than 10 minutes (600 seconds) to
+                                finish. This depends on speed of VM but current runs are 180s. -->
+                            <forkedProcessTimeoutInSeconds>600</forkedProcessTimeoutInSeconds>
                         </configuration>
                     </plugin>
                 </plugins>


### PR DESCRIPTION
I tested this code on Jenkins as build #160 and it passed. Interestingly the builds have been taking longer lately: 4mins, 5mins, 6mins and #160 took 9mins. 