### PR TITLE
Commands sync up to mvnw as per Jenkins pipeline

### DIFF
--- a/.github/workflows/lsp4jakarta.yaml
+++ b/.github/workflows/lsp4jakarta.yaml
@@ -21,11 +21,11 @@ jobs:
           java-version: 17
       - name: Build LSP4Jakarta JDT LS Extension with Maven
         working-directory: ./jakarta.jdt
-        run: xvfb-run -a mvn -B install --file pom.xml
+        run: xvfb-run -a ./mvnw clean install -B --file pom.xml
       - name: Build LSP4Jakarta Language Server with Maven
         working-directory: ./jakarta.ls
-        run: mvn clean install --file pom.xml 
+        run: ./mvnw clean install -B --file pom.xml
       - name: Build LSP4Jakarta Eclipse client plug-in with Maven
         working-directory: ./jakarta.eclipse
-        run: xvfb-run -a mvn -B install --file pom.xml
+        run: xvfb-run -a ./mvnw clean install -B --file pom.xml
           

--- a/buildAll.sh
+++ b/buildAll.sh
@@ -1,11 +1,11 @@
 set -e
 
 # build LSP4Jakarta JDT Extension
-cd jakarta.jdt && mvn clean; mvn install && cd ..
+cd jakarta.jdt && ./mvnw clean install -B && cd ..
 
 # build LSP4Jakarta LS
-cd jakarta.ls && mvn clean; mvn install && cd ..
+cd jakarta.ls && ./mvnw clean install -B && cd ..
 
 # build LSP4Jakarta Eclipse plugin
-cd jakarta.eclipse && mvn clean; mvn install && cd ..
+cd jakarta.eclipse && ./mvnw clean install -B && cd ..
 


### PR DESCRIPTION
Commands sync up to mvnw as per Jenkins pipeline. Jenkins uses mvnw verify -B mostly, but since we need artifact creations for both the below files and keep it intact as before, we follow mvnw install -B (this covers verify too):
1. .github/workflows/lsp4jakarta.yaml
2. buildAll.sh