### PR TITLE
Added diagnostic to detect manual JSON-P parsing and recommend Jakarta JSON Binding

### DIFF
--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/internal/jsonp/Constants.java
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/internal/jsonp/Constants.java
@@ -27,4 +27,16 @@ public class Constants {
     public static final String JAKARTA_JSON_OBJECT_BUILDER_FQ_NAME = "jakarta.json.JsonObjectBuilder";
     public static final String JAKARTA_JSON_BUILDER_ADD_METHOD = "add";
     public static final String JAKARTA_JSON_ARRAY_BUILDER_FQ_NAME = "jakarta.json.JsonArrayBuilder";
+
+    /* JSON-B recommendation constants */
+    public static final String CREATE_READER = "createReader";
+    public static final String READ_OBJECT = "readObject";
+    public static final String JSON_READER_FQ_NAME = "jakarta.json.JsonReader";
+    public static final String JSON_OBJECT_FQ_NAME = "jakarta.json.JsonObject";
+    public static final String GET_STRING = "getString";
+    public static final String GET_INT = "getInt";
+    public static final String GET_BOOLEAN = "getBoolean";
+    public static final String GET_JSON_NUMBER = "getJsonNumber";
+    public static final String GET_JSON_OBJECT = "getJsonObject";
+    public static final String GET_JSON_ARRAY = "getJsonArray";
 }

--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/internal/jsonp/ErrorCode.java
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/internal/jsonp/ErrorCode.java
@@ -20,7 +20,8 @@ import org.eclipse.lsp4jakarta.jdt.core.java.diagnostics.IJavaErrorCode;
 public enum ErrorCode implements IJavaErrorCode {
     InvalidJsonCreatePointerTarget,
     InvalidJsonObjectBuilderKey,
-    InvalidJsonArrayBuilderValue;
+    InvalidJsonArrayBuilderValue,
+    UseJsonbInsteadOfManualParsing;
 
     /**
      * {@inheritDoc}

--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/internal/jsonp/JsonpDiagnosticParticipant.java
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/internal/jsonp/JsonpDiagnosticParticipant.java
@@ -24,10 +24,12 @@ import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.jdt.core.ICompilationUnit;
 import org.eclipse.jdt.core.JavaModelException;
+import org.eclipse.jdt.core.dom.ASTNode;
 import org.eclipse.jdt.core.dom.CastExpression;
 import org.eclipse.jdt.core.dom.Expression;
 import org.eclipse.jdt.core.dom.IMethodBinding;
 import org.eclipse.jdt.core.dom.ITypeBinding;
+import org.eclipse.jdt.core.dom.MethodDeclaration;
 import org.eclipse.jdt.core.dom.MethodInvocation;
 import org.eclipse.jdt.core.dom.NullLiteral;
 import org.eclipse.jdt.core.dom.StringLiteral;
@@ -102,6 +104,10 @@ public class JsonpDiagnosticParticipant implements IJavaDiagnosticsParticipant {
         createDiagnosticsForBuilderInvocations(unit, createArrayBuilderMethodInvocations, diagnostics, context, uri,
                                                Messages.getMessage("ErrorMessageJsonPArrayValueNonNull"),
                                                ErrorCode.InvalidJsonArrayBuilderValue);
+
+        // Detect manual JSON parsing patterns that should use JSON-B
+        detectManualJsonParsingPatterns(unit, allMethodInvocations, diagnostics, context, uri);
+
         return diagnostics;
     }
 
@@ -225,5 +231,147 @@ public class JsonpDiagnosticParticipant implements IJavaDiagnosticsParticipant {
         }
 
         return false;
+    }
+
+    /**
+     * Detects manual JSON parsing patterns where Json.createReader() is used
+     * followed by manual field mapping with getter methods like getString(), getInt(), etc.
+     *
+     * @param unit the compilation unit
+     * @param allMethodInvocations all method invocations in the file
+     * @param diagnostics the list to add diagnostics to
+     * @param context the diagnostics context
+     * @param uri the file URI
+     */
+    private void detectManualJsonParsingPatterns(ICompilationUnit unit, List<MethodInvocation> allMethodInvocations,
+                                                 List<Diagnostic> diagnostics, JavaDiagnosticsContext context, String uri) {
+        List<MethodInvocation> createReaderInvocations = allMethodInvocations.stream().filter(mi -> isJsonCreateReaderInvocation(mi)).collect(Collectors.toList());
+
+        for (MethodInvocation createReaderInvocation : createReaderInvocations) {
+            if (isManualParsingPattern(createReaderInvocation, allMethodInvocations)) {
+                String msg = Messages.getMessage("UseJsonbInsteadOfManualParsing");
+                try {
+                    Range range = JDTUtils.toRange(unit, createReaderInvocation.getStartPosition(),
+                                                   createReaderInvocation.getLength());
+                    diagnostics.add(context.createDiagnostic(uri, msg, range, Constants.DIAGNOSTIC_SOURCE,
+                                                             ErrorCode.UseJsonbInsteadOfManualParsing,
+                                                             DiagnosticSeverity.Warning));
+                } catch (JavaModelException e) {
+                    LOGGER.log(Level.SEVERE, "Cannot calculate diagnostics for manual JSON parsing", e.getMessage());
+                }
+            }
+        }
+    }
+
+    /**
+     * Checks if a method invocation is Json.createReader().
+     *
+     * @param mi the method invocation
+     * @return true if it's Json.createReader()
+     */
+    private boolean isJsonCreateReaderInvocation(MethodInvocation mi) {
+        if (!Constants.CREATE_READER.equals(mi.getName().getIdentifier())) {
+            return false;
+        }
+        IMethodBinding binding = mi.resolveMethodBinding();
+        if (binding == null) {
+            return false;
+        }
+        ITypeBinding declaringClass = binding.getDeclaringClass();
+        return declaringClass != null && Constants.JSON_FQ_NAME.equals(declaringClass.getQualifiedName());
+    }
+
+    /**
+     * Checks if a createReader invocation is part of a manual parsing pattern.
+     *
+     * @param createReaderInvocation the createReader method invocation
+     * @param allMethodInvocations all method invocations in the file
+     * @return true if manual parsing pattern is detected
+     */
+    private boolean isManualParsingPattern(MethodInvocation createReaderInvocation,
+                                           List<MethodInvocation> allMethodInvocations) {
+        boolean hasReadObject = allMethodInvocations.stream().anyMatch(mi -> isReadObjectInvocation(mi) &&
+                                                                             isInSameMethodScope(createReaderInvocation, mi));
+
+        if (!hasReadObject) {
+            return false;
+        }
+
+        return allMethodInvocations.stream().anyMatch(mi -> isJsonObjectGetterMethod(mi) &&
+                                                            isInSameMethodScope(createReaderInvocation, mi));
+    }
+
+    /**
+     * Checks if a method invocation is JsonReader.readObject().
+     *
+     * @param mi the method invocation
+     * @return true if it's readObject() on a JsonReader
+     */
+    private boolean isReadObjectInvocation(MethodInvocation mi) {
+        if (!Constants.READ_OBJECT.equals(mi.getName().getIdentifier())) {
+            return false;
+        }
+        IMethodBinding binding = mi.resolveMethodBinding();
+        if (binding == null) {
+            return false;
+        }
+        ITypeBinding declaringClass = binding.getDeclaringClass();
+        return declaringClass != null && Constants.JSON_READER_FQ_NAME.equals(declaringClass.getQualifiedName());
+    }
+
+    /**
+     * Checks if a method invocation is a JsonObject getter method
+     * (getString, getInt, getBoolean, etc.).
+     *
+     * @param mi the method invocation
+     * @return true if it's a JsonObject getter method
+     */
+    private boolean isJsonObjectGetterMethod(MethodInvocation mi) {
+        String methodName = mi.getName().getIdentifier();
+        if (!methodName.equals(Constants.GET_STRING) &&
+            !methodName.equals(Constants.GET_INT) &&
+            !methodName.equals(Constants.GET_BOOLEAN) &&
+            !methodName.equals(Constants.GET_JSON_NUMBER) &&
+            !methodName.equals(Constants.GET_JSON_OBJECT) &&
+            !methodName.equals(Constants.GET_JSON_ARRAY)) {
+            return false;
+        }
+        IMethodBinding binding = mi.resolveMethodBinding();
+        if (binding == null) {
+            return false;
+        }
+        ITypeBinding declaringClass = binding.getDeclaringClass();
+        return declaringClass != null && Constants.JSON_OBJECT_FQ_NAME.equals(declaringClass.getQualifiedName());
+    }
+
+    /**
+     * Returns the nearest enclosing MethodDeclaration for the given AST node,
+     * or null if none exists.
+     *
+     * @param node the AST node
+     * @return the enclosing MethodDeclaration, or null
+     */
+    private MethodDeclaration getEnclosingMethod(ASTNode node) {
+        ASTNode current = node.getParent();
+        while (current != null) {
+            if (current instanceof MethodDeclaration) {
+                return (MethodDeclaration) current;
+            }
+            current = current.getParent();
+        }
+        return null;
+    }
+
+    /**
+     * Checks if two method invocations are in the same enclosing method declaration.
+     *
+     * @param mi1 first method invocation
+     * @param mi2 second method invocation
+     * @return true if both invocations are enclosed by the same MethodDeclaration
+     */
+    private boolean isInSameMethodScope(MethodInvocation mi1, MethodInvocation mi2) {
+        MethodDeclaration enclosing1 = getEnclosingMethod(mi1);
+        MethodDeclaration enclosing2 = getEnclosingMethod(mi2);
+        return enclosing1 != null && enclosing1 == enclosing2;
     }
 }

--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/resources/org/eclipse/lsp4jakarta/jdt/core/messages/messages.properties
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/resources/org/eclipse/lsp4jakarta/jdt/core/messages/messages.properties
@@ -184,6 +184,7 @@ ErrorMessageJsonbNonPublicProtectedStaticNestedClass = Static nested class {0} m
 CreatePointerErrorMessage = Json.createPointer target must be a sequence of '/' prefixed tokens or an empty String.
 ErrorMessageJsonPObjectKeyNonNull = The JsonObjectBuilder class does not allow null to be used as a name while building the JSON object.
 ErrorMessageJsonPArrayValueNonNull = JsonArrayBuilder class does not allow null to be used as a value while building the JSON array.
+UseJsonbInsteadOfManualParsing = Manual JSON parsing with JSON-P and field-by-field mapping detected. Consider using Jakarta JSON Binding (JSON-B) for automatic object-to-JSON mapping with Jsonb.fromJson() for better performance and maintainability.
 
 # PersistenceEntityDiagnosticsParticipant
 EntityNoFinalMethods = A class using the @Entity annotation cannot contain any methods that are declared final.

--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.test/projects/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/jsonp/ManualJsonParsingToPojoExample.java
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.test/projects/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/jsonp/ManualJsonParsingToPojoExample.java
@@ -15,6 +15,8 @@ package io.openliberty.sample.jakarta.jsonp;
 import jakarta.json.Json;
 import jakarta.json.JsonObject;
 import jakarta.json.JsonReader;
+import jakarta.json.bind.Jsonb;
+import jakarta.json.bind.JsonbBuilder;
 import java.io.StringReader;
 
 public class ManualJsonParsingToPojoExample {
@@ -70,5 +72,11 @@ public class ManualJsonParsingToPojoExample {
         user.setAge(jsonObject.getInt("age"));
         
         return user;
+    }
+
+    // Valid: Using JSON-B for direct POJO deserialization - no diagnostic expected
+    public User parseUserWithJsonb(String jsonString) {
+        Jsonb jsonb = JsonbBuilder.create();
+        return jsonb.fromJson(jsonString, User.class);
     }
 }

--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.test/projects/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/jsonp/ManualJsonParsingToPojoExample.java
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.test/projects/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/jsonp/ManualJsonParsingToPojoExample.java
@@ -1,0 +1,74 @@
+/*******************************************************************************
+ * Copyright (c) 2026 IBM Corporation and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial implementation
+ *******************************************************************************/
+package io.openliberty.sample.jakarta.jsonp;
+
+import jakarta.json.Json;
+import jakarta.json.JsonObject;
+import jakarta.json.JsonReader;
+import java.io.StringReader;
+
+public class ManualJsonParsingToPojoExample {
+
+    public static class User {
+        private String name;
+        private int age;
+
+        public User() {}
+
+        public User(String name, int age) {
+            this.name = name;
+            this.age = age;
+        }
+
+        public String getName() { return name; }
+        public void setName(String name) { this.name = name; }
+
+        public int getAge() { return age; }
+        public void setAge(int age) { this.age = age; }
+    }
+
+    // Example 1: Manual parsing with Json.createReader followed by manual mapping
+    public User parseUserManually(String jsonString) {
+        JsonReader reader = Json.createReader(new StringReader(jsonString));
+        JsonObject json = reader.readObject();
+        
+        User user = new User();
+        user.setName(json.getString("name"));
+        user.setAge(json.getInt("age"));
+        
+        return user;
+    }
+
+    // Example 2: Another manual parsing pattern
+    public User anotherManualParsing(String jsonString) {
+        JsonObject json = Json.createReader(new StringReader(jsonString)).readObject();
+        
+        User user = new User();
+        user.setName(json.getString("name"));
+        user.setAge(json.getInt("age"));
+        
+        return user;
+    }
+
+    // Example 3: Multiple field mappings
+    public User complexManualParsing(String jsonString) {
+        JsonReader jsonReader = Json.createReader(new StringReader(jsonString));
+        JsonObject jsonObject = jsonReader.readObject();
+        
+        User user = new User();
+        user.setName(jsonObject.getString("name"));
+        user.setAge(jsonObject.getInt("age"));
+        
+        return user;
+    }
+}

--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.test/src/main/java/org/eclipse/lsp4jakarta/jdt/test/jsonp/JakartaJsonpTest.java
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.test/src/main/java/org/eclipse/lsp4jakarta/jdt/test/jsonp/JakartaJsonpTest.java
@@ -102,4 +102,27 @@ public class JakartaJsonpTest extends BaseJakartaTest {
         assertJavaDiagnostics(diagnosticsParams, IJDT_UTILS, invalidJsonArrayBuilderStringNull, invalidJsonArrayBuilderNull, invalidArrayBuilderTwoParamString);
     }
 
+    @Test
+    public void manualJsonParsingToPojoPattern() throws Exception {
+        IJavaProject javaProject = loadJavaProject("jakarta-sample", "");
+        IFile javaFile = javaProject.getProject().getFile(
+                                                          new Path("src/main/java/io/openliberty/sample/jakarta/jsonp/ManualJsonParsingToPojoExample.java"));
+        String uri = javaFile.getLocation().toFile().toURI().toString();
+
+        JakartaJavaDiagnosticsParams diagnosticsParams = new JakartaJavaDiagnosticsParams();
+        diagnosticsParams.setUris(Arrays.asList(uri));
+
+        Diagnostic d1 = d(41, 28, 75,
+                          "Manual JSON parsing with JSON-P and field-by-field mapping detected. Consider using Jakarta JSON Binding (JSON-B) for automatic object-to-JSON mapping with Jsonb.fromJson() for better performance and maintainability.",
+                          DiagnosticSeverity.Warning, "jakarta-jsonp", "UseJsonbInsteadOfManualParsing");
+        Diagnostic d2 = d(53, 26, 73,
+                          "Manual JSON parsing with JSON-P and field-by-field mapping detected. Consider using Jakarta JSON Binding (JSON-B) for automatic object-to-JSON mapping with Jsonb.fromJson() for better performance and maintainability.",
+                          DiagnosticSeverity.Warning, "jakarta-jsonp", "UseJsonbInsteadOfManualParsing");
+        Diagnostic d3 = d(64, 32, 79,
+                          "Manual JSON parsing with JSON-P and field-by-field mapping detected. Consider using Jakarta JSON Binding (JSON-B) for automatic object-to-JSON mapping with Jsonb.fromJson() for better performance and maintainability.",
+                          DiagnosticSeverity.Warning, "jakarta-jsonp", "UseJsonbInsteadOfManualParsing");
+
+        assertJavaDiagnostics(diagnosticsParams, IJDT_UTILS, d1, d2, d3);
+    }
+
 }

--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.test/src/main/java/org/eclipse/lsp4jakarta/jdt/test/jsonp/JakartaJsonpTest.java
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.test/src/main/java/org/eclipse/lsp4jakarta/jdt/test/jsonp/JakartaJsonpTest.java
@@ -112,13 +112,13 @@ public class JakartaJsonpTest extends BaseJakartaTest {
         JakartaJavaDiagnosticsParams diagnosticsParams = new JakartaJavaDiagnosticsParams();
         diagnosticsParams.setUris(Arrays.asList(uri));
 
-        Diagnostic d1 = d(41, 28, 75,
+        Diagnostic d1 = d(43, 28, 75,
                           "Manual JSON parsing with JSON-P and field-by-field mapping detected. Consider using Jakarta JSON Binding (JSON-B) for automatic object-to-JSON mapping with Jsonb.fromJson() for better performance and maintainability.",
                           DiagnosticSeverity.Warning, "jakarta-jsonp", "UseJsonbInsteadOfManualParsing");
-        Diagnostic d2 = d(53, 26, 73,
+        Diagnostic d2 = d(55, 26, 73,
                           "Manual JSON parsing with JSON-P and field-by-field mapping detected. Consider using Jakarta JSON Binding (JSON-B) for automatic object-to-JSON mapping with Jsonb.fromJson() for better performance and maintainability.",
                           DiagnosticSeverity.Warning, "jakarta-jsonp", "UseJsonbInsteadOfManualParsing");
-        Diagnostic d3 = d(64, 32, 79,
+        Diagnostic d3 = d(66, 32, 79,
                           "Manual JSON parsing with JSON-P and field-by-field mapping detected. Consider using Jakarta JSON Binding (JSON-B) for automatic object-to-JSON mapping with Jsonb.fromJson() for better performance and maintainability.",
                           DiagnosticSeverity.Warning, "jakarta-jsonp", "UseJsonbInsteadOfManualParsing");
 


### PR DESCRIPTION
Fixes #782 

Adding a new diagnostic to detect manual JSON parsing anti-patterns where developers use Jakarta JSON Processing (JSON-P) APIs like Json.createReader(), readObject(), and field-by-field getter methods (getString(), getInt(), etc.) to manually map JSON to POJOs. The diagnostic issues a warning recommending the use of Jakarta JSON Binding (JSON-B) with Jsonb.fromJson() instead, which provides automatic object-to-JSON mapping for better performance and maintainability. The implementation includes detection logic in JsonpDiagnosticParticipant, new error codes and constants, comprehensive test cases, and follows the existing diagnostic patterns in the codebase.