### PR TITLE
Added diagnostic and quick-fix for conflicting EJB session bean stereotype annotations

### DIFF
--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/plugin.xml
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/plugin.xml
@@ -328,6 +328,9 @@
       <codeAction kind="quickfix"
                   targetDiagnostic="jakarta-ejb#MissingPublicNoArgConstructor"
                   class="org.eclipse.lsp4jakarta.jdt.internal.ejb.InsertPublicNoArgConstructorQuickFix" />
+      <codeAction kind="quickfix"
+                  targetDiagnostic="jakarta-ejb#ConflictingSessionBeanAnnotations"
+                  class="org.eclipse.lsp4jakarta.jdt.internal.ejb.RemoveConflictingSessionBeanAnnotationsQuickFix" />
    </extension>
    
    <!-- CDI -->

--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/commons/codeaction/JakartaCodeActionId.java
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/commons/codeaction/JakartaCodeActionId.java
@@ -84,6 +84,7 @@ public enum JakartaCodeActionId implements ICodeActionId {
     CDIReplaceScopeAnnotations,
     // EJB
     EJBInsertPublicCtrtToClass,
+    EJBRemoveConflictingSessionBeanAnnotations,
     CDIRemoveConditionalObserverAnnotations,
     CDIRemoveNotifyObserverAttribute,
     CDIRemoveObserverConflictParams,

--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/internal/ejb/Constants.java
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/internal/ejb/Constants.java
@@ -26,8 +26,8 @@ public class Constants {
     public static final String DIAGNOSTIC_CODE_MISSING_PUBLIC_CONSTRUCTOR = "MissingPublicNoArgConstructor";
 
     public static final String[] SESSION_BEAN_ANNOTATIONS = {
-            STATELESS_FQ_NAME,
-            STATEFUL_FQ_NAME,
-            SINGLETON_FQ_NAME
+                                                              STATELESS_FQ_NAME,
+                                                              STATEFUL_FQ_NAME,
+                                                              SINGLETON_FQ_NAME
     };
 }

--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/internal/ejb/EjbDiagnosticsParticipant.java
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/internal/ejb/EjbDiagnosticsParticipant.java
@@ -70,10 +70,7 @@ public class EjbDiagnosticsParticipant implements IJavaDiagnosticsParticipant {
 
             if (!sessionBeanAnnotations.isEmpty()) {
                 if (sessionBeanAnnotations.size() > 1) {
-                    String annotationNames = sessionBeanAnnotations.stream()
-                            .map(DiagnosticUtils::getSimpleName)
-                            .map(name -> "@" + name)
-                            .collect(Collectors.joining(", "));
+                    String annotationNames = sessionBeanAnnotations.stream().map(DiagnosticUtils::getSimpleName).map(name -> "@" + name).collect(Collectors.joining(", "));
                     String message = Messages.getMessage("SessionBeanConflictingAnnotations", annotationNames);
                     Range range = PositionUtils.toNameRange(type, context.getUtils());
                     diagnostics.add(context.createDiagnostic(uri, message, range,

--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/internal/ejb/EjbDiagnosticsParticipant.java
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/internal/ejb/EjbDiagnosticsParticipant.java
@@ -15,6 +15,7 @@ package org.eclipse.lsp4jakarta.jdt.internal.ejb;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.eclipse.core.runtime.CoreException;
@@ -32,6 +33,8 @@ import org.eclipse.lsp4jakarta.jdt.core.utils.PositionUtils;
 import org.eclipse.lsp4jakarta.jdt.internal.DiagnosticUtils;
 import org.eclipse.lsp4jakarta.jdt.internal.Messages;
 import org.eclipse.lsp4jakarta.jdt.internal.core.ls.JDTUtilsLSImpl;
+
+import com.google.gson.Gson;
 
 /**
  * EJB diagnostic participant that validates session beans.
@@ -66,6 +69,20 @@ public class EjbDiagnosticsParticipant implements IJavaDiagnosticsParticipant {
                                                                                              Constants.SESSION_BEAN_ANNOTATIONS);
 
             if (!sessionBeanAnnotations.isEmpty()) {
+                if (sessionBeanAnnotations.size() > 1) {
+                    String annotationNames = sessionBeanAnnotations.stream()
+                            .map(DiagnosticUtils::getSimpleName)
+                            .map(name -> "@" + name)
+                            .collect(Collectors.joining(", "));
+                    String message = Messages.getMessage("SessionBeanConflictingAnnotations", annotationNames);
+                    Range range = PositionUtils.toNameRange(type, context.getUtils());
+                    diagnostics.add(context.createDiagnostic(uri, message, range,
+                                                             Constants.DIAGNOSTIC_SOURCE,
+                                                             (new Gson().toJsonTree(sessionBeanAnnotations)),
+                                                             ErrorCode.ConflictingSessionBeanAnnotations,
+                                                             DiagnosticSeverity.Error));
+                }
+
                 ConstructorInfoDiagnosticHelper constructorInfo = ConstructorInfoDiagnosticHelper.getConstructorInfo(type);
 
                 if (constructorInfo.hasConstructor() && !constructorInfo.hasValidPublicNoArgsConstructor()) {

--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/internal/ejb/ErrorCode.java
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/internal/ejb/ErrorCode.java
@@ -20,7 +20,8 @@ import org.eclipse.lsp4jakarta.jdt.core.java.diagnostics.IJavaErrorCode;
  */
 public enum ErrorCode implements IJavaErrorCode {
 
-    MissingPublicNoArgConstructor;
+    MissingPublicNoArgConstructor,
+    ConflictingSessionBeanAnnotations;
 
     @Override
     public String getCode() {

--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/internal/ejb/RemoveConflictingSessionBeanAnnotationsQuickFix.java
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/internal/ejb/RemoveConflictingSessionBeanAnnotationsQuickFix.java
@@ -1,0 +1,80 @@
+/*******************************************************************************
+* Copyright (c) 2026 IBM Corporation and others.
+*
+* This program and the accompanying materials are made available under the
+* terms of the Eclipse Public License v. 2.0 which is available at
+* http://www.eclipse.org/legal/epl-2.0.
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*     IBM Corporation - initial API and implementation
+*******************************************************************************/
+package org.eclipse.lsp4jakarta.jdt.internal.ejb;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.jdt.core.dom.ASTNode;
+import org.eclipse.jdt.core.dom.IBinding;
+import org.eclipse.lsp4j.CodeAction;
+import org.eclipse.lsp4j.Diagnostic;
+import org.eclipse.lsp4jakarta.commons.codeaction.JakartaCodeActionId;
+import org.eclipse.lsp4jakarta.jdt.core.java.codeaction.JavaCodeActionContext;
+import org.eclipse.lsp4jakarta.jdt.core.java.codeaction.RemoveAnnotationConflictQuickFix;
+
+import com.google.gson.JsonArray;
+
+/**
+ * Removes all conflicting session bean annotations except the one to keep.
+ */
+public class RemoveConflictingSessionBeanAnnotationsQuickFix extends RemoveAnnotationConflictQuickFix {
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getParticipantId() {
+        return RemoveConflictingSessionBeanAnnotationsQuickFix.class.getName();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    protected JakartaCodeActionId getCodeActionId() {
+        return JakartaCodeActionId.EJBRemoveConflictingSessionBeanAnnotations;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public List<? extends CodeAction> getCodeActions(JavaCodeActionContext context, Diagnostic diagnostic,
+                                                     IProgressMonitor monitor) throws CoreException {
+        List<CodeAction> codeActions = new ArrayList<>();
+        ASTNode node = context.getCoveredNode();
+        IBinding parentType = getBinding(node);
+
+        if (parentType != null) {
+            JsonArray diagnosticData = (JsonArray) diagnostic.getData();
+            List<String> annotations = IntStream.range(0, diagnosticData.size())
+                    .mapToObj(idx -> diagnosticData.get(idx).getAsString())
+                    .collect(Collectors.toList());
+
+            for (String annotation : annotations) {
+                List<String> resultingAnnotations = new ArrayList<>(annotations);
+                resultingAnnotations.remove(annotation);
+
+                createCodeAction(diagnostic, context, parentType, codeActions,
+                                 resultingAnnotations.toArray(new String[] {}));
+            }
+        }
+
+        return codeActions;
+    }
+}

--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/internal/ejb/RemoveConflictingSessionBeanAnnotationsQuickFix.java
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/internal/ejb/RemoveConflictingSessionBeanAnnotationsQuickFix.java
@@ -62,9 +62,7 @@ public class RemoveConflictingSessionBeanAnnotationsQuickFix extends RemoveAnnot
 
         if (parentType != null) {
             JsonArray diagnosticData = (JsonArray) diagnostic.getData();
-            List<String> annotations = IntStream.range(0, diagnosticData.size())
-                    .mapToObj(idx -> diagnosticData.get(idx).getAsString())
-                    .collect(Collectors.toList());
+            List<String> annotations = IntStream.range(0, diagnosticData.size()).mapToObj(idx -> diagnosticData.get(idx).getAsString()).collect(Collectors.toList());
 
             for (String annotation : annotations) {
                 List<String> resultingAnnotations = new ArrayList<>(annotations);

--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/resources/org/eclipse/lsp4jakarta/jdt/core/messages/messages.properties
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/resources/org/eclipse/lsp4jakarta/jdt/core/messages/messages.properties
@@ -123,6 +123,7 @@ ProducerFieldWithNamedAnnotation = Producer field ''{0}'' must not declare a bea
 
 # SessionBeanDiagnosticsParticipant
 SessionBeanNoArgConstructor = Session beans must have a public no-arg constructor.
+SessionBeanConflictingAnnotations = A class cannot be annotated with multiple session bean types: {0}.
 
 # ManagedBeanQuickFix
 ReplaceCurrentScope = Replace current scope with {0}

--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.test/projects/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/ejb/InvalidConflictingStatefulSingleton.java
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.test/projects/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/ejb/InvalidConflictingStatefulSingleton.java
@@ -1,0 +1,16 @@
+package io.openliberty.sample.jakarta.ejb;
+
+import jakarta.ejb.Singleton;
+import jakarta.ejb.Stateful;
+
+@Stateful
+@Singleton
+public class InvalidConflictingStatefulSingleton {
+
+    public InvalidConflictingStatefulSingleton() {
+    }
+
+    public String hello() {
+        return "Hello";
+    }
+}

--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.test/projects/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/ejb/InvalidConflictingStatelessSingleton.java
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.test/projects/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/ejb/InvalidConflictingStatelessSingleton.java
@@ -1,0 +1,16 @@
+package io.openliberty.sample.jakarta.ejb;
+
+import jakarta.ejb.Singleton;
+import jakarta.ejb.Stateless;
+
+@Stateless
+@Singleton
+public class InvalidConflictingStatelessSingleton {
+
+    public InvalidConflictingStatelessSingleton() {
+    }
+
+    public String hello() {
+        return "Hello";
+    }
+}

--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.test/projects/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/ejb/InvalidConflictingStatelessStateful.java
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.test/projects/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/ejb/InvalidConflictingStatelessStateful.java
@@ -1,0 +1,16 @@
+package io.openliberty.sample.jakarta.ejb;
+
+import jakarta.ejb.Stateful;
+import jakarta.ejb.Stateless;
+
+@Stateless
+@Stateful
+public class InvalidConflictingStatelessStateful {
+
+    public InvalidConflictingStatelessStateful() {
+    }
+
+    public String hello() {
+        return "Hello";
+    }
+}

--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.test/src/main/java/org/eclipse/lsp4jakarta/jdt/test/ejb/SessionBeanConstructorTest.java
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.test/src/main/java/org/eclipse/lsp4jakarta/jdt/test/ejb/SessionBeanConstructorTest.java
@@ -22,6 +22,8 @@ import static org.eclipse.lsp4jakarta.jdt.test.core.JakartaForJavaAssert.te;
 
 import java.util.Arrays;
 
+import com.google.gson.Gson;
+
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.runtime.Path;
 import org.eclipse.jdt.core.IJavaProject;
@@ -84,6 +86,66 @@ public class SessionBeanConstructorTest extends BaseJakartaTest {
     public void testInvalidSingletonBeanPrivate() throws Exception {
         assertMissingPublicNoArgConstructor("src/main/java/io/openliberty/sample/jakarta/ejb/InvalidSingletonBeanPrivate.java",
                                             40, "public InvalidSingletonBeanPrivate() {\n\t}\n\n\t");
+    }
+
+    @Test
+    public void testConflictingStatelessStateful() throws Exception {
+        String uri = getJavaFileUri("src/main/java/io/openliberty/sample/jakarta/ejb/InvalidConflictingStatelessStateful.java");
+        JakartaJavaDiagnosticsParams diagnosticsParams = createDiagnosticsParams(uri);
+
+        Diagnostic conflictingDiagnostic = d(7, 13, 48,
+                                             "A class cannot be annotated with multiple session bean types: @Stateless, @Stateful.",
+                                             DiagnosticSeverity.Error, "jakarta-ejb", "ConflictingSessionBeanAnnotations");
+        conflictingDiagnostic.setData(new Gson().toJsonTree(Arrays.asList("jakarta.ejb.Stateless", "jakarta.ejb.Stateful")));
+
+        assertJavaDiagnostics(diagnosticsParams, IJDT_UTILS, conflictingDiagnostic);
+
+        JakartaJavaCodeActionParams codeActionParams = createCodeActionParams(uri, conflictingDiagnostic);
+        TextEdit removeStatefulEdit = te(6, 0, 7, 0, "");
+        CodeAction keepStatelessAction = ca(uri, "Remove @Stateful", conflictingDiagnostic, removeStatefulEdit);
+        TextEdit removeStatelessEdit = te(5, 0, 6, 0, "");
+        CodeAction keepStatefulAction = ca(uri, "Remove @Stateless", conflictingDiagnostic, removeStatelessEdit);
+        assertJavaCodeAction(codeActionParams, IJDT_UTILS, keepStatelessAction, keepStatefulAction);
+    }
+
+    @Test
+    public void testConflictingStatelessSingleton() throws Exception {
+        String uri = getJavaFileUri("src/main/java/io/openliberty/sample/jakarta/ejb/InvalidConflictingStatelessSingleton.java");
+        JakartaJavaDiagnosticsParams diagnosticsParams = createDiagnosticsParams(uri);
+
+        Diagnostic conflictingDiagnostic = d(7, 13, 49,
+                                             "A class cannot be annotated with multiple session bean types: @Stateless, @Singleton.",
+                                             DiagnosticSeverity.Error, "jakarta-ejb", "ConflictingSessionBeanAnnotations");
+        conflictingDiagnostic.setData(new Gson().toJsonTree(Arrays.asList("jakarta.ejb.Stateless", "jakarta.ejb.Singleton")));
+
+        assertJavaDiagnostics(diagnosticsParams, IJDT_UTILS, conflictingDiagnostic);
+
+        JakartaJavaCodeActionParams codeActionParams = createCodeActionParams(uri, conflictingDiagnostic);
+        TextEdit removeSingletonEdit = te(6, 0, 7, 0, "");
+        CodeAction keepStatelessAction = ca(uri, "Remove @Singleton", conflictingDiagnostic, removeSingletonEdit);
+        TextEdit removeStatelessEdit = te(5, 0, 6, 0, "");
+        CodeAction keepSingletonAction = ca(uri, "Remove @Stateless", conflictingDiagnostic, removeStatelessEdit);
+        assertJavaCodeAction(codeActionParams, IJDT_UTILS, keepStatelessAction, keepSingletonAction);
+    }
+
+    @Test
+    public void testConflictingStatefulSingleton() throws Exception {
+        String uri = getJavaFileUri("src/main/java/io/openliberty/sample/jakarta/ejb/InvalidConflictingStatefulSingleton.java");
+        JakartaJavaDiagnosticsParams diagnosticsParams = createDiagnosticsParams(uri);
+
+        Diagnostic conflictingDiagnostic = d(7, 13, 48,
+                                             "A class cannot be annotated with multiple session bean types: @Stateful, @Singleton.",
+                                             DiagnosticSeverity.Error, "jakarta-ejb", "ConflictingSessionBeanAnnotations");
+        conflictingDiagnostic.setData(new Gson().toJsonTree(Arrays.asList("jakarta.ejb.Stateful", "jakarta.ejb.Singleton")));
+
+        assertJavaDiagnostics(diagnosticsParams, IJDT_UTILS, conflictingDiagnostic);
+
+        JakartaJavaCodeActionParams codeActionParams = createCodeActionParams(uri, conflictingDiagnostic);
+        TextEdit removeSingletonEdit = te(6, 0, 7, 0, "");
+        CodeAction keepStatefulAction = ca(uri, "Remove @Singleton", conflictingDiagnostic, removeSingletonEdit);
+        TextEdit removeStatefulEdit = te(5, 0, 6, 0, "");
+        CodeAction keepSingletonAction = ca(uri, "Remove @Stateful", conflictingDiagnostic, removeStatefulEdit);
+        assertJavaCodeAction(codeActionParams, IJDT_UTILS, keepStatefulAction, keepSingletonAction);
     }
 
     private void assertMissingPublicNoArgConstructor(String projectRelativePath, int endCharacter,


### PR DESCRIPTION
Fixes #770 

Added a diagnostic `ConflictingSessionBeanAnnotations` to `EjbDiagnosticsParticipant` that reports an error when a class is annotated with more than one of `@Stateless`, `@Stateful`, or `@Singleton`, as these are mutually exclusive session bean type designators per the Jakarta Enterprise Beans 4.0 specification.
Additionally a quick-fix `RemoveConflictingSessionBeanAnnotationsQuickFix` is registered in `plugin.xml` to allow the user to remove any one of the conflicting annotations, leaving the class with a single valid session bean type. Tests and sample fixtures are included to cover all conflicting annotation combinations.