### PR TITLE
Rename rest_class and rest_get snippet prefixes to jakarta_rest_class and jakarta_rest_get

### DIFF
--- a/jakarta.ls/src/main/resources/restfulWs.json
+++ b/jakarta.ls/src/main/resources/restfulWs.json
@@ -1,6 +1,6 @@
 {
     "Jakarta RESTful Web Services - new resource class": {
-      "prefix": "rest_class",
+      "prefix": "jakarta_rest_class",
       "body": [
         "package ${1:packagename};",
         "",
@@ -26,7 +26,7 @@
       }
     },
     "Jakarta RESTful Web Services - new GET resource method": {
-      "prefix": "rest_get",
+      "prefix": "jakarta_rest_get",
       "body": [
         "@GET",
         "@Produces(MediaType.TEXT_PLAIN)",

--- a/jakarta.ls/src/test/java/org/eclipse/lsp4jakarta/snippets/JakartaSnippetRegistryTest.java
+++ b/jakarta.ls/src/test/java/org/eclipse/lsp4jakarta/snippets/JakartaSnippetRegistryTest.java
@@ -127,16 +127,16 @@ public class JakartaSnippetRegistryTest {
     }
 
     /**
-     * Jakarta RESTful Web Services snippets - rest_class, rest_get
+     * Jakarta RESTful Web Services snippets - jakarta_rest_class, jakarta_rest_get
      * rest_post, rest_put, rest_delete, rest_head
      */
     @Test
     public void restfulWebServicesSnippetsPrefixTest() {
-        Optional<Snippet> restClassSnippet = findByPrefix("rest_class", registry);
-        assertTrue("rest_class Java snippet is not present in SnippetRegistry", restClassSnippet.isPresent());
+        Optional<Snippet> restClassSnippet = findByPrefix("jakarta_rest_class", registry);
+        assertTrue("jakarta_rest_class Java snippet is not present in SnippetRegistry", restClassSnippet.isPresent());
 
-        Optional<Snippet> restGetSnippet = findByPrefix("rest_get", registry);
-        assertTrue("rest_get Java snippet is not present in SnippetRegistry", restGetSnippet.isPresent());
+        Optional<Snippet> restGetSnippet = findByPrefix("jakarta_rest_get", registry);
+        assertTrue("jakarta_rest_get Java snippet is not present in SnippetRegistry", restGetSnippet.isPresent());
 
         Optional<Snippet> restPostSnippet = findByPrefix("rest_post", registry);
         assertTrue("rest_post Java snippet is not present in SnippetRegistry", restPostSnippet.isPresent());


### PR DESCRIPTION
# Problem

When Liberty Tools is installed, `rest_class` and `rest_get` snippet completions appear twice in any `.java` file 
(reported here: https://github.com/OpenLiberty/liberty-tools-vscode/issues/408, https://github.com/OpenLiberty/liberty-tools-vscode/issues/409)

Both lsp4jakarta and lsp4mp (`redhat.vscode-microprofile`, which is an `extensionDependency` of Liberty Tools and always auto-installed alongside it) define these two snippets. VS Code merges completions from all active language servers with no deduplication, causing both to appear.

From the user's perspective the expansions are identical. The only technical difference is that lsp4mp's version uses `${ee-namespace}` (resolves to either `javax` or `jakarta` depending on the project) while lsp4jakarta's version is hardcoded to `jakarta`.

# Fix

This is a **tactical fix** while a longer-term common layer solution could be worked on (see [org.eclipse.jdtls.featureext](https://github.com/eclipse-lsp4mp/org.eclipse.jdtls.featureext)), which will address duplicate snippets more comprehensively through refactoring across both lsp4mp and lsp4jakarta.

Rename the `prefix` field for the two colliding snippets in `restfulWs.json`:

| Snippet | Old prefix | New prefix |
|---|---|---|
| Jakarta RESTful Web Services - new resource class | `rest_class` | `jakarta_rest_class` |
| Jakarta RESTful Web Services - new GET resource method | `rest_get` | `jakarta_rest_get` |

This removes the collision with lsp4mp's `rest_class` and `rest_get` while keeping both lsp4jakarta snippets fully discoverable. This is because `jakarta_rest_class` and `jakarta_rest_get` still contain the word `rest` and VS Code's matching surfaces them when a user types `rest`.

No other fields are changed. The remaining five snippets (`rest_post`, `rest_put`, `rest_delete`, `rest_head`, `rest_client_class`) are unaffected since lsp4mp does not provide those.