### PR TITLE
JDT LS 1.60.0 version upgrade (#926)

### DIFF
--- a/.github/workflows/lsp4jakarta.yaml
+++ b/.github/workflows/lsp4jakarta.yaml
@@ -15,10 +15,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@v1
         with:
-          java-version: 17
+          java-version: 21
       - name: Build LSP4Jakarta JDT LS Extension with Maven
         working-directory: ./jakarta.jdt
         run: xvfb-run -a ./mvnw clean install -B --file pom.xml

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -21,7 +21,7 @@ In the following sections, we document how to build and test using the Eclipse I
 
 ## Prerequisites
 
-[Java SE 17](https://adoptium.net/en-GB/marketplace/), [Maven](https://maven.apache.org/download.cgi), and [Eclipse](https://www.eclipse.org/downloads/) (Eclipse IDE for Enterprise Java and Web Developers is recommended) are required to build the Eclipse LSP4Jakarta project.
+[Java SE 21](https://adoptium.net/en-GB/marketplace/), [Maven](https://maven.apache.org/download.cgi), and [Eclipse](https://www.eclipse.org/downloads/) (Eclipse IDE for Enterprise Java and Web Developers is recommended) are required to build the Eclipse LSP4Jakarta project.
 
 Ensure the [Eclipse Plug-in Development Environment (PDE)](https://marketplace.eclipse.org/content/eclipse-pde-plug-development-environment) is installed in your Eclipse workspace.
 
@@ -46,7 +46,7 @@ The following instructions explain how to set up your Eclipse IDE workspace.
     <img src="/docs/images/building_project_explorer.png" alt="Eclipse project explorer" height="30%" width="30%"/>
 
 
-4. Ensure that the Java projects are being built with `JavaSE-17` (Right-click project --> "Properties" --> "Java Build Path" --> "Libraries")
+4. Ensure that the Java projects are being built with `JavaSE-21` (Right-click project --> "Properties" --> "Java Build Path" --> "Libraries")
 
 5. Configure the Java build path for the `org.eclipse.lsp4jakarta.lsp4e.core` project:
 
@@ -78,7 +78,7 @@ The following instructions explain how to set up your Eclipse IDE workspace.
 &nbsp;- *Bundle 'org.apache.commons.lang3' cannot be resolved* in Eclipse workspace  
 &nbsp;Solution: [#46](https://github.com/eclipse/lsp4jakarta/issues/46)
 
-2. If during initial setup `mvn verify` returns errors or compilation failures, verify that you are using [JavaSE-17](https://www.oracle.com/ca-en/java/technologies/downloads/#java17). You may have to configure `$JAVA_HOME` variable and make sure it is pointing to the correct location.
+2. If during initial setup `mvn verify` returns errors or compilation failures, verify that you are using [JavaSE-21](https://www.oracle.com/ca-en/java/technologies/downloads/#java21). You may have to configure `$JAVA_HOME` variable and make sure it is pointing to the correct location.
 
 ## Run and Debug
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,7 @@
 pipeline {
   agent any
   tools {
-    jdk 'temurin-jdk17-latest'
+    jdk 'temurin-jdk21-latest'
   }
   environment {
     MAVEN_HOME = "$WORKSPACE/.m2/"

--- a/Release.Jenkinsfile
+++ b/Release.Jenkinsfile
@@ -1,7 +1,7 @@
 pipeline {
   agent any
   tools {
-    jdk 'temurin-jdk17-latest'
+    jdk 'temurin-jdk21-latest'
   }
   environment {
     MAVEN_HOME = "$WORKSPACE/.m2/"
@@ -23,15 +23,15 @@ pipeline {
           sh "VERSION=${params.VERSION}"
           sh '''
                 cd jakarta.jdt
-                ./mvnw -Dtycho.mode=maven org.eclipse.tycho:tycho-versions-plugin:4.0.10:set-version -DnewVersion=$VERSION
+                ./mvnw -Dtycho.mode=maven org.eclipse.tycho:tycho-versions-plugin:5.0.2:set-version -DnewVersion=$VERSION
                 ./mvnw versions:set-scm-tag -DnewTag=$VERSION
                 ./mvnw clean deploy -B -Peclipse-sign -Dcbi.jarsigner.skip=false
                 cd ../jakarta.ls
-                ./mvnw -Dtycho.mode=maven org.eclipse.tycho:tycho-versions-plugin:4.0.10:set-version -DnewVersion=$VERSION
+                ./mvnw -Dtycho.mode=maven org.eclipse.tycho:tycho-versions-plugin:5.0.2:set-version -DnewVersion=$VERSION
                 ./mvnw versions:set-scm-tag -DnewTag=$VERSION
                 ./mvnw clean deploy -B -Peclipse-sign -Dcbi.jarsigner.skip=false
                 cd ../jakarta.eclipse
-                ./mvnw -Dtycho.mode=maven org.eclipse.tycho:tycho-versions-plugin:4.0.10:set-version -DnewVersion=$VERSION
+                ./mvnw -Dtycho.mode=maven org.eclipse.tycho:tycho-versions-plugin:5.0.2:set-version -DnewVersion=$VERSION
                 cd ..
               '''
         }
@@ -86,13 +86,13 @@ pipeline {
           sh "$VERSION_SNAPSHOT=${params.VERSION_SNAPSHOT}"
           sh '''
             cd jakarta.jdt
-            ./mvnw -Dtycho.mode=maven org.eclipse.tycho:tycho-versions-plugin:4.0.10:set-version -DnewVersion=$VERSION_SNAPSHOT
+            ./mvnw -Dtycho.mode=maven org.eclipse.tycho:tycho-versions-plugin:5.0.2:set-version -DnewVersion=$VERSION_SNAPSHOT
             ./mvnw versions:set-scm-tag -DnewTag=$VERSION_SNAPSHOT
             cd ../jakarta.ls
-            ./mvnw -Dtycho.mode=maven org.eclipse.tycho:tycho-versions-plugin:4.0.10:set-version -DnewVersion=$VERSION_SNAPSHOT
+            ./mvnw -Dtycho.mode=maven org.eclipse.tycho:tycho-versions-plugin:5.0.2:set-version -DnewVersion=$VERSION_SNAPSHOT
             ./mvnw versions:set-scm-tag -DnewTag=$VERSION_SNAPSHOT
             cd ../jakarta.eclipse
-            ./mvnw -Dtycho.mode=maven org.eclipse.tycho:tycho-versions-plugin:4.0.10:set-version -DnewVersion=$VERSION_SNAPSHOT
+            ./mvnw -Dtycho.mode=maven org.eclipse.tycho:tycho-versions-plugin:5.0.2:set-version -DnewVersion=$VERSION_SNAPSHOT
             cd ..
           '''
         }

--- a/jakarta.eclipse/.mvn/wrapper/maven-wrapper.properties
+++ b/jakarta.eclipse/.mvn/wrapper/maven-wrapper.properties
@@ -14,5 +14,5 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.10/apache-maven-3.9.10-bin.zip
-wrapperUrl=https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.3.2/maven-wrapper-3.3.2.jar
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.11/apache-maven-3.9.11-bin.zip
+wrapperUrl=https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.3.4/maven-wrapper-3.3.4.jar

--- a/jakarta.eclipse/org.eclipse.lsp4jakarta.lsp4e.core/META-INF/MANIFEST.MF
+++ b/jakarta.eclipse/org.eclipse.lsp4jakarta.lsp4e.core/META-INF/MANIFEST.MF
@@ -18,7 +18,7 @@ Require-Bundle:
  org.eclipse.lsp4j.jsonrpc,
  org.eclipse.lsp4j,
  org.eclipse.lsp4jakarta.jdt.core
-Bundle-RequiredExecutionEnvironment: JavaSE-17
+Bundle-RequiredExecutionEnvironment: JavaSE-21
 Automatic-Module-Name: org.eclipse.lsp4jakarta.lsp4e.core
 Bundle-ActivationPolicy: lazy
 Bundle-ClassPath: server/org.eclipse.lsp4jakarta.ls-jar-with-dependencies.jar,

--- a/jakarta.eclipse/org.eclipse.lsp4jakarta.lsp4e.feature.source/feature.xml
+++ b/jakarta.eclipse/org.eclipse.lsp4jakarta.lsp4e.feature.source/feature.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<feature
+      id="org.eclipse.lsp4jakarta.lsp4e.feature.source"
+      label="org.eclipse.lsp4jakarta.lsp4e.feature Source"
+      version="0.2.7.qualifier">
+
+   <description url="http://www.example.com/description">
+      [Enter Feature Description here.]
+   </description>
+
+   <copyright url="http://www.example.com/copyright">
+      [Enter Copyright Description here.]
+   </copyright>
+
+   <license url="http://www.example.com/license">
+      [Enter License Description here.]
+   </license>
+
+   <includes
+         id="org.eclipse.lsp4jakarta.lsp4e.feature"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.eclipse.lsp4jakarta.lsp4e.core.source"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+</feature>

--- a/jakarta.eclipse/org.eclipse.lsp4jakarta.lsp4e.feature.source/pom.xml
+++ b/jakarta.eclipse/org.eclipse.lsp4jakarta.lsp4e.feature.source/pom.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project
+    xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <artifactId>org.eclipse.lsp4jakarta.lsp4e</artifactId>
+        <groupId>org.eclipse.lsp4jakarta</groupId>
+        <version>0.2.7-SNAPSHOT</version>
+    </parent>
+    <artifactId>org.eclipse.lsp4jakarta.lsp4e.feature.source</artifactId>
+    <packaging>eclipse-feature</packaging>
+    <name>Eclipse LSP4Jakarta LSP4E Feature Source</name>
+    <description>Eclipse LSP4Jakarta LSP4E Feature Source</description>
+    <organization>
+        <name>Eclipse LSP4Jakarta</name>
+        <url>https://github.com/eclipse/lsp4jakarta</url>
+    </organization>
+    <licenses>
+        <license>
+            <name>EPL-2.0</name>
+            <url>https://www.eclipse.org/legal/epl-2.0/</url>
+            <comments>Eclipse Public License 2.0</comments>
+        </license>
+    </licenses>
+</project>

--- a/jakarta.eclipse/org.eclipse.lsp4jakarta.lsp4e.test/META-INF/MANIFEST.MF
+++ b/jakarta.eclipse/org.eclipse.lsp4jakarta.lsp4e.test/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-Vendor: Eclipse LSP4Jakarta
 Bundle-SymbolicName: org.eclipse.lsp4jakarta.lsp4e.test
 Bundle-Version: 0.2.7.qualifier
 Fragment-Host: org.eclipse.lsp4jakarta.lsp4e.core;bundle-version="0.2.0"
-Bundle-RequiredExecutionEnvironment: JavaSE-17
+Bundle-RequiredExecutionEnvironment: JavaSE-21
 Require-Bundle: org.eclipse.jdt.junit4.runtime;bundle-version="1.1.0",
  org.junit;bundle-version="4.11"
 Automatic-Module-Name: org.eclipse.lsp4jakarta.lsp4e.test

--- a/jakarta.eclipse/pom.xml
+++ b/jakarta.eclipse/pom.xml
@@ -24,17 +24,17 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <maven.compiler.source>17</maven.compiler.source>
-        <maven.compiler.target>17</maven.compiler.target>
-        <tycho.version>4.0.10</tycho.version>
+        <maven.compiler.source>21</maven.compiler.source>
+        <maven.compiler.target>21</maven.compiler.target>
+        <tycho.version>5.0.2</tycho.version>
         <tycho.test.platformArgs />
         <tycho.test.jvmArgs>-Xmx512m ${tycho.test.platformArgs}</tycho.test.jvmArgs>
     </properties>
     <repositories>
         <repository>
-            <id>2024-06</id>
+            <id>2026-03</id>
             <layout>p2</layout>
-            <url>http://download.eclipse.org/releases/2024-06</url>
+            <url>https://download.eclipse.org/releases/2026-03</url>
         </repository>
     </repositories>
     <pluginRepositories>
@@ -56,7 +56,7 @@
                 <artifactId>target-platform-configuration</artifactId>
                 <version>${tycho.version}</version>
                 <configuration>
-                    
+                    <executionEnvironment>JavaSE-21</executionEnvironment>
                     <pomDependencies>consider</pomDependencies>
                     
                 </configuration>
@@ -128,51 +128,12 @@
                 <tycho.test.platformArgs>-XstartOnFirstThread</tycho.test.platformArgs>
             </properties>
         </profile>
-        <profile>
-            <id>source-feature</id>
-            <activation>
-                <file>
-                    <exists>feature.xml</exists>
-                </file>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.eclipse.tycho</groupId>
-                        <artifactId>tycho-source-plugin</artifactId>
-                        <version>${tycho.version}</version>
-                        <executions>
-                            <execution>
-                                <id>feature-source</id>
-                                <phase>package</phase>
-                                <goals>
-                                    <goal>feature-source</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
-                    <plugin>
-                        <groupId>org.eclipse.tycho</groupId>
-                        <artifactId>tycho-p2-plugin</artifactId>
-                        <version>${tycho.version}</version>
-                        <executions>
-                            <execution>
-                                <id>attach-p2-metadata</id>
-                                <phase>package</phase>
-                                <goals>
-                                    <goal>p2-metadata</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
     </profiles>
     <modules>
         <module>org.eclipse.lsp4jakarta.lsp4e.core</module>
         <module>org.eclipse.lsp4jakarta.lsp4e.test</module>
         <module>org.eclipse.lsp4jakarta.lsp4e.feature</module>
+        <module>org.eclipse.lsp4jakarta.lsp4e.feature.source</module>
         <module>org.eclipse.lsp4jakarta.lsp4e.site</module>
     </modules>
 </project>

--- a/jakarta.jdt/.mvn/wrapper/maven-wrapper.properties
+++ b/jakarta.jdt/.mvn/wrapper/maven-wrapper.properties
@@ -14,5 +14,5 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.10/apache-maven-3.9.10-bin.zip
-wrapperUrl=https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.3.2/maven-wrapper-3.3.2.jar
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.11/apache-maven-3.9.11-bin.zip
+wrapperUrl=https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.3.4/maven-wrapper-3.3.4.jar

--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/META-INF/MANIFEST.MF
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/META-INF/MANIFEST.MF
@@ -23,7 +23,7 @@ Require-Bundle:
  org.apache.commons.lang3,
  com.google.gson,
  com.google.guava
-Bundle-RequiredExecutionEnvironment: JavaSE-17
+Bundle-RequiredExecutionEnvironment: JavaSE-21
 Bundle-ActivationPolicy: lazy
 Bundle-ClassPath: .
 Export-Package: 

--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/internal/core/java/ChangeUtil.java
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/internal/core/java/ChangeUtil.java
@@ -16,13 +16,14 @@ package org.eclipse.lsp4jakarta.jdt.internal.core.java;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-
+import java.util.stream.Collectors;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.jdt.core.ICompilationUnit;
 import org.eclipse.jdt.core.IJavaElement;
 import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.Range;
 import org.eclipse.lsp4j.ResourceOperation;
+import org.eclipse.lsp4j.SnippetTextEdit;
 import org.eclipse.lsp4j.TextDocumentEdit;
 import org.eclipse.lsp4j.VersionedTextDocumentIdentifier;
 import org.eclipse.lsp4j.WorkspaceEdit;
@@ -109,9 +110,13 @@ public class ChangeUtil {
                 changes = new ArrayList<>();
                 root.setDocumentChanges(changes);
             }
-
-            VersionedTextDocumentIdentifier identifier = new VersionedTextDocumentIdentifier(uri, 0);
-            TextDocumentEdit documentEdit = new TextDocumentEdit(identifier, converter.convert());
+            //Modified for jdtls API upgrade 1.0.0 version
+            VersionedTextDocumentIdentifier identifier = new VersionedTextDocumentIdentifier();
+            identifier.setUri(uri);
+            identifier.setVersion(0);
+            TextDocumentEdit documentEdit = new TextDocumentEdit();
+            documentEdit.setTextDocument(identifier);
+            documentEdit.setEdits(converter.convert().stream().map(Either::<org.eclipse.lsp4j.TextEdit, SnippetTextEdit> forLeft).collect(Collectors.toList()));
             changes.add(Either.forLeft(documentEdit));
         } else {
 

--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/internal/core/java/TextEditConverter.java
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/internal/core/java/TextEditConverter.java
@@ -16,7 +16,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-
+import java.util.stream.Collectors;
+import org.eclipse.lsp4j.SnippetTextEdit;
 import org.apache.commons.lang3.StringUtils;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.jdt.core.ICompilationUnit;
@@ -26,6 +27,7 @@ import org.eclipse.jface.text.BadLocationException;
 import org.eclipse.jface.text.Document;
 import org.eclipse.lsp4j.TextDocumentEdit;
 import org.eclipse.lsp4j.VersionedTextDocumentIdentifier;
+import org.eclipse.lsp4j.jsonrpc.messages.Either;
 import org.eclipse.lsp4jakarta.jdt.core.utils.IJDTUtils;
 import org.eclipse.text.edits.CopySourceEdit;
 import org.eclipse.text.edits.CopyTargetEdit;
@@ -78,9 +80,14 @@ public class TextEditConverter extends TextEditVisitor {
     }
 
     public TextDocumentEdit convertToTextDocumentEdit(int version) {
-        VersionedTextDocumentIdentifier identifier = new VersionedTextDocumentIdentifier(version);
+        //Modified for jdtls API upgrade 1.0.0 version
+        VersionedTextDocumentIdentifier identifier = new VersionedTextDocumentIdentifier();
         identifier.setUri(uri);
-        return new TextDocumentEdit(identifier, this.convert());
+        identifier.setVersion(version);
+        TextDocumentEdit documentEdit = new TextDocumentEdit();
+        documentEdit.setTextDocument(identifier);
+        documentEdit.setEdits(this.convert().stream().map(Either::<org.eclipse.lsp4j.TextEdit, SnippetTextEdit> forLeft).collect(Collectors.toList()));
+        return documentEdit;
     }
 
     /*

--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.test/META-INF/MANIFEST.MF
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.test/META-INF/MANIFEST.MF
@@ -5,9 +5,8 @@ Bundle-Vendor: Eclipse LSP4Jakarta
 Bundle-SymbolicName: org.eclipse.lsp4jakarta.jdt.test
 Bundle-Version: 0.2.7.qualifier
 Automatic-Module-Name: org.eclipse.lsp4jakarta.jdt.test
-Bundle-RequiredExecutionEnvironment: JavaSE-17
+Bundle-RequiredExecutionEnvironment: JavaSE-21
 Require-Bundle: org.junit,
- org.apache.commons.io,
  org.eclipse.lsp4j,
  org.eclipse.lsp4j.jsonrpc,
  org.eclipse.jdt.core,

--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.test/pom.xml
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.test/pom.xml
@@ -32,6 +32,13 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.eclipse.tycho</groupId>
+                <artifactId>tycho-surefire-plugin</artifactId>
+                <configuration>
+                    <argLine>-Dosgi.requiredJavaVersion=21</argLine>
+                </configuration>
+            </plugin>
+            <plugin>
                 <artifactId>maven-assembly-plugin</artifactId>
                 <executions>
                     <execution>

--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.test/projects/demo-servlet-no-diagnostics/.classpath
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.test/projects/demo-servlet-no-diagnostics/.classpath
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="src" output="target/classes" path="src/main/java">
+		<attributes>
+			<attribute name="optional" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry excluding="**" kind="src" output="target/classes" path="src/main/resources">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+			<attribute name="optional" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="src" output="target/test-classes" path="src/test/java">
+		<attributes>
+			<attribute name="optional" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+			<attribute name="test" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry excluding="**" kind="src" output="target/test-classes" path="src/test/resources">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+			<attribute name="test" value="true"/>
+			<attribute name="optional" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.m2e.MAVEN2_CLASSPATH_CONTAINER">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="src" path="target/generated-sources/annotations">
+		<attributes>
+			<attribute name="optional" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+			<attribute name="ignore_optional_problems" value="true"/>
+			<attribute name="m2e-apt" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="src" output="target/test-classes" path="target/generated-test-sources/test-annotations">
+		<attributes>
+			<attribute name="optional" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+			<attribute name="ignore_optional_problems" value="true"/>
+			<attribute name="m2e-apt" value="true"/>
+			<attribute name="test" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="output" path="target/classes"/>
+</classpath>

--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.test/src/main/java/org/eclipse/lsp4jakarta/jdt/test/core/JakartaForJavaAssert.java
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.test/src/main/java/org/eclipse/lsp4jakarta/jdt/test/core/JakartaForJavaAssert.java
@@ -26,10 +26,12 @@ import org.eclipse.lsp4j.CodeAction;
 import org.eclipse.lsp4j.CodeActionContext;
 import org.eclipse.lsp4j.Diagnostic;
 import org.eclipse.lsp4j.DiagnosticSeverity;
+import org.eclipse.lsp4j.MarkupContent;
 import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.PublishDiagnosticsParams;
 import org.eclipse.lsp4j.Range;
 import org.eclipse.lsp4j.ResourceOperation;
+import org.eclipse.lsp4j.SnippetTextEdit;
 import org.eclipse.lsp4j.TextDocumentEdit;
 import org.eclipse.lsp4j.TextDocumentIdentifier;
 import org.eclipse.lsp4j.TextEdit;
@@ -88,9 +90,12 @@ public class JakartaForJavaAssert {
             ca.setTitle(replaceNewLineCharacters(ca.getTitle()));
             List<Either<TextDocumentEdit, ResourceOperation>> tdes = ca.getEdit().getDocumentChanges();
             for (Either<TextDocumentEdit, ResourceOperation> tde : tdes) {
-                List<TextEdit> tes = tde.getLeft().getEdits();
-                for (TextEdit te : tes) {
-                    te.setNewText(replaceNewLineCharacters(te.getNewText()));
+                //Modified for jdtls API upgrade 1.0.0 version
+                List<Either<TextEdit, SnippetTextEdit>> tes = tde.getLeft().getEdits();
+                for (Either<TextEdit, SnippetTextEdit> te : tes) {
+                    if (te.isLeft()) {
+                        te.getLeft().setNewText(replaceNewLineCharacters(te.getLeft().getNewText()));
+                    }
                 }
             }
         }
@@ -107,10 +112,11 @@ public class JakartaForJavaAssert {
         CodeAction codeAction = new CodeAction();
         codeAction.setTitle(title);
         codeAction.setDiagnostics(Arrays.asList(d));
-
-        VersionedTextDocumentIdentifier versionedTextDocumentIdentifier = new VersionedTextDocumentIdentifier(uri, 0);
-
-        TextDocumentEdit textDocumentEdit = new TextDocumentEdit(versionedTextDocumentIdentifier, Arrays.asList(te));
+        //Modified for jdtls API upgrade 1.0.0 version
+        VersionedTextDocumentIdentifier versionedTextDocumentIdentifier = new VersionedTextDocumentIdentifier();
+        versionedTextDocumentIdentifier.setUri(uri);
+        versionedTextDocumentIdentifier.setVersion(0);
+        TextDocumentEdit textDocumentEdit = new TextDocumentEdit(versionedTextDocumentIdentifier, Arrays.stream(te).map(Either::<TextEdit, SnippetTextEdit> forLeft).collect(Collectors.toList()));
         WorkspaceEdit workspaceEdit = new WorkspaceEdit(Arrays.asList(Either.forLeft(textDocumentEdit)));
         workspaceEdit.setChanges(Collections.emptyMap());
         codeAction.setEdit(workspaceEdit);
@@ -195,7 +201,7 @@ public class JakartaForJavaAssert {
         List<Diagnostic> received = actual;
         final boolean filterMessage;
         if (expected != null && !expected.isEmpty()
-            && (expected.get(0).getMessage() == null || expected.get(0).getMessage().isEmpty())) {
+            && isEmptyMessage(expected.get(0).getMessage())) {
             filterMessage = true;
         } else {
             filterMessage = false;
@@ -228,6 +234,58 @@ public class JakartaForJavaAssert {
      * @return new string without '\r' for new lines
      */
     public static String replaceNewLineCharacters(String source) {
-        return source.replaceAll("\r\n", "\n");
+        return source == null ? null : source.replaceAll("\r\n", "\n");
     }
+
+    /**
+     * Added for jdtls API upgrade 1.0.0 version
+     * Normalizes line endings in a diagnostic message represented as either plain
+     * text or markup content.
+     * <p>
+     * This keeps test comparisons stable across platforms by converting Windows
+     * CRLF line endings to LF while preserving the original {@link Either} shape.
+     *
+     * @param source the diagnostic message to normalize
+     * @return a normalized message with LF line endings, or {@code null} if the
+     *         input is {@code null}
+     */
+    public static Either<String, MarkupContent> replaceNewLineCharacters(Either<String, MarkupContent> source) {
+        if (source == null) {
+            return null;
+        }
+        if (source.isLeft()) {
+            return Either.forLeft(replaceNewLineCharacters(source.getLeft()));
+        }
+        MarkupContent markup = source.getRight();
+        if (markup == null) {
+            return Either.forRight(null);
+        }
+        MarkupContent normalized = new MarkupContent();
+        normalized.setKind(markup.getKind());
+        normalized.setValue(replaceNewLineCharacters(markup.getValue()));
+        return Either.forRight(normalized);
+    }
+
+    /**
+     * Added for jdtls API upgrade 1.0.0 version
+     * Returns whether the given diagnostic message is effectively empty.
+     * <p>
+     * A message is considered empty when it is {@code null}, when its plain-text
+     * value is empty, or when its markup-content value is empty.
+     *
+     * @param message the diagnostic message to inspect
+     * @return {@code true} if the message is absent or empty; {@code false}
+     *         otherwise
+     */
+    public static boolean isEmptyMessage(Either<String, MarkupContent> message) {
+        if (message == null) {
+            return true;
+        }
+        if (message.isLeft()) {
+            return message.getLeft() == null || message.getLeft().isEmpty();
+        }
+        MarkupContent markup = message.getRight();
+        return markup == null || markup.getValue() == null || markup.getValue().isEmpty();
+    }
+
 }

--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.tp/org.eclipse.lsp4jakarta.jdt.target
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.tp/org.eclipse.lsp4jakarta.jdt.target
@@ -18,24 +18,23 @@
 			<unit id="org.eclipse.equinox.app" version="0.0.0" />
 			<unit id="org.eclipse.equinox.registry" version="0.0.0" />
 			<unit id="org.eclipse.osgi" version="0.0.0" />
-			<unit id="org.eclipse.osgi.services" version="0.0.0" />
 			<unit id="org.eclipse.m2e.core" version="0.0.0" />
 			<unit id="org.eclipse.m2e.jdt" version="0.0.0" />
 			<unit id="org.eclipse.m2e.maven.runtime" version="0.0.0" />
 			<unit id="org.eclipse.buildship.core" version="0.0.0" />
 			<unit id="org.eclipse.lsp4e" version="0.0.0" />
-			<unit id="org.apache.commons.io" version="0.0.0" />
+			<unit id="org.apache.commons.commons-io" version="0.0.0" />
 			<unit id="org.junit" version="0.0.0" />
 			<unit id="org.eclipse.lsp4e" version="0.0.0" />
 			<unit id="org.eclipse.lsp4j" version="0.0.0" />
 			<unit id="org.eclipse.lsp4j.jsonrpc" version="0.0.0" />
-			<repository location="http://download.eclipse.org/releases/2024-06/" />
+			<repository location="https://download.eclipse.org/releases/2026-03/" />
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="true"
 			includeMode="planner" includeSource="true" type="InstallableUnit">
 			<unit id="org.eclipse.jdt.ls.core" version="0.0.0" />
 			<repository
-				location="https://download.eclipse.org/jdtls/milestones/1.43.0/repository/" />
+				location="https://download.eclipse.org/jdtls/milestones/1.60.0/repository/" />
 		</location>
 	</locations>
 </target>

--- a/jakarta.jdt/pom.xml
+++ b/jakarta.jdt/pom.xml
@@ -30,9 +30,9 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <maven.compiler.source>17</maven.compiler.source>
-        <maven.compiler.target>17</maven.compiler.target>
-        <tycho.version>4.0.10</tycho.version>
+        <maven.compiler.source>21</maven.compiler.source>
+        <maven.compiler.target>21</maven.compiler.target>
+        <tycho.version>5.0.2</tycho.version>
         <tycho.scmUrl>scm:git:https://github.com/eclipse/lsp4jakarta</tycho.scmUrl>
         <tycho.generateSourceReferences>true</tycho.generateSourceReferences> 
         <releases.repo.id>repo.eclipse.org</releases.repo.id>
@@ -99,6 +99,7 @@
 							</artifact>
 						</target>
 						<pomDependencies>consider</pomDependencies>
+						<executionEnvironment>JavaSE-21</executionEnvironment>
 					</configuration>
 				</plugin>
 				<plugin>

--- a/jakarta.ls/.mvn/wrapper/maven-wrapper.properties
+++ b/jakarta.ls/.mvn/wrapper/maven-wrapper.properties
@@ -14,5 +14,5 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.10/apache-maven-3.9.10-bin.zip
-wrapperUrl=https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.3.2/maven-wrapper-3.3.2.jar
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.11/apache-maven-3.9.11-bin.zip
+wrapperUrl=https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.3.4/maven-wrapper-3.3.4.jar

--- a/jakarta.ls/pom.xml
+++ b/jakarta.ls/pom.xml
@@ -29,10 +29,10 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <tycho.version>4.0.10</tycho.version>
-        <maven.compiler.source>17</maven.compiler.source>
-        <maven.compiler.target>17</maven.compiler.target>
-        <lsp4j.version>0.23.1</lsp4j.version>
+        <tycho.version>5.0.2</tycho.version>
+        <maven.compiler.source>21</maven.compiler.source>
+        <maven.compiler.target>21</maven.compiler.target>
+        <lsp4j.version>1.0.0</lsp4j.version>
         <releases.repo.id>repo.eclipse.org</releases.repo.id>
         <releases.repo.url>https://repo.eclipse.org/content/repositories/lsp4jakarta-releases/</releases.repo.url>
         <snapshots.repo.id>repo.eclipse.org</snapshots.repo.id>


### PR DESCRIPTION
Upgrades done:

- [x] Upgraded JDT LS version from https://github.com/eclipse-jdtls/eclipse.jdt.ls/releases/tag/v1.43.0 to https://github.com/eclipse-jdtls/eclipse.jdt.ls/releases/tag/v1.60.0
- [x] Upgraded lsp4j from 0.23.1 to 1.0.0
- [x] Upgraded tycho from 4.0.10 to 5.0.2
- [x] Upgraded Java from 17 to 21
- [x] Upgraded apache-maven from [3.9.10](https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.10) to [3.9.11](https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.11)
- [x] Upgraded maven-wrapper from [3.3.2](https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.3.2) to [3.3.4](https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.3.4)

Fixes https://github.com/eclipse-lsp4jakarta/lsp4jakarta/issues/906

Commits:

* Modified pom and manifest files

Includes lsp4j, tycho, java & eclipse upgrades

* Removed bundle range

* tp file update

* ChangeUtil API changes

* File API change

* TextEditConverter API changes

* Developing.md java version change

* Jenkins file JDT version change

* GIT yaml file java version change

* .classpath java version change

* Added classpath file for demo project

* PR comments

* Correction

* Added solution for feature-source deprecation